### PR TITLE
added support for custom user model

### DIFF
--- a/chroniker/models.py
+++ b/chroniker/models.py
@@ -21,7 +21,6 @@ import settings as _settings
 
 import django
 from django.conf import settings
-from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
 from django.core.mail import send_mail
 from django.core.management import call_command
@@ -386,7 +385,7 @@ class Job(models.Model):
         editable=False)
     
     subscribers = models.ManyToManyField(
-        User,
+        settings.AUTH_USER_MODEL,
         related_name='subscribed_jobs',
         blank=True,
         limit_choices_to={'is_staff':True})


### PR DESCRIPTION
In my project, there is a custom user model, so chroniker won't work here. With this little change subscribers always points to the correct user model. For backward compatibility you could advise developers to always set 

```
AUTH_USER_MODEL='auth.User'
```

in their settings.py file, if they have early django versions.
