### PR TITLE
Fixed error in admin panel. Renamed user column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .project
 .pydevproject
 .settings
+*.pyc
 build
 dist
 MANIFEST

--- a/chroniker/migrations/0018_freeze_user_model.py
+++ b/chroniker/migrations/0018_freeze_user_model.py
@@ -17,22 +17,21 @@ else:
 # so instead of using orm['auth.User'] we can use orm[user_orm_label]
 user_orm_label = '%s.%s' % (User._meta.app_label, User._meta.object_name)
 user_model_label = '%s.%s' % (User._meta.app_label, User._meta.module_name)
-
+user_column_name = '%s_id' % User._meta.module_name
 
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
-        # We don't need to do anything in migrations
-        # itself because the table names have been
-        # made constant. But we do need to freeze the models.
         # Based on the solution at:
         # http://kevindias.com/writing/django-custom-user-models-south-and-reusable-apps/
-        pass
+        # Update: We will need to update the table column too
+        # as the 'through' workaround will require changes in admin fieldsets too
+        # However renaming won't cause any changes to existing deployments
+        db.rename_column('chroniker_job_subscribers', 'user_id', user_column_name)
 
 
     def backwards(self, orm):
-        # Nothings needs to be done.
-        pass
+        db.rename_column('chroniker_job_subscribers', user_column_name, 'user_id')
 
     models = {
         u'chroniker.job': {

--- a/chroniker/models.py
+++ b/chroniker/models.py
@@ -510,7 +510,6 @@ class Job(models.Model):
     
     subscribers = models.ManyToManyField(
         settings.AUTH_USER_MODEL,
-        through='SubscribedJob',
         related_name='subscribed_jobs',
         blank=True,
         limit_choices_to={'is_staff':True})
@@ -1442,19 +1441,6 @@ class Log(models.Model):
         if time_ago:
             q = q.filter(run_start_datetime__lte = time_ago)
         q.delete()
-
-
-class SubscribedJob(models.Model):
-    """
-    A Many-To-Many field table to link Subcribers to Jobs
-    """
-    user = models.ForeignKey(settings.AUTH_USER_MODEL,
-                             db_column='user_id')
-    job = models.ForeignKey(Job)
-
-    class Meta:
-        db_table = 'chroniker_job_subscribers'
-
 
 class MonitorManager(models.Manager):
     


### PR DESCRIPTION
The previous work-around using the 'through' setting in ManyToMany relationship caused the error in admin panel as 'through' fieldsets are not displayed. To avoid the through workaround, we will need to rename the user_id column to the custom user model column.

I have fixed the migration for the same.

Please let me know if any changes are required.
