### PR TITLE
Use django.jQuery in AdminSite templates

### DIFF
--- a/chroniker/templates/admin/chroniker/job/duration_graph.html
+++ b/chroniker/templates/admin/chroniker/job/duration_graph.html
@@ -44,6 +44,6 @@
             }
         );
     });
-})(jQuery);
+})(django.jQuery);
 </script>
 {% endblock %}


### PR DESCRIPTION
The global jQuery object is 'undefined' in the AdminSite, but accessible through "django.jQuery"

https://docs.djangoproject.com/en/1.8/ref/contrib/admin/#jquery