### PR TITLE
make sure next_run has a value set before applying tz

### DIFF
--- a/chroniker/models.py
+++ b/chroniker/models.py
@@ -834,7 +834,8 @@ class Job(models.Model):
             self.current_hostname = None
             self.current_pid = None
         
-        self.next_run = utils.make_aware(self.next_run, tz)
+        if self.next_run:
+            self.next_run = utils.make_aware(self.next_run, tz)
         
         super(Job, self).save(*args, **kwargs)
         


### PR DESCRIPTION
raises an issue if you create a job which is disabled on first save