### PR TITLE
Should use base_url instead of BASE_SECURE_URL

### DIFF
--- a/chroniker/models.py
+++ b/chroniker/models.py
@@ -1464,7 +1464,7 @@ class Log(models.Model):
                 base_url = 'http://' + current_site.domain
         
         if base_url:
-            admin_link = settings.BASE_SECURE_URL \
+            admin_link = base_url \
                 + utils.get_admin_change_url(self.job)
             body = 'To manage this job please visit: ' \
                 + admin_link + '\n\n' + body


### PR DESCRIPTION
Should use base_url instead of BASE_SECURE_URL. Otherwise the BASE_SECURE_URL is always required.