### PR TITLE
Create migration to reflect changes to models.py

### DIFF
--- a/chroniker/migrations/0002_auto_20160517_1429.py
+++ b/chroniker/migrations/0002_auto_20160517_1429.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='job',
             name='hostname',
-            field=models.CharField(max_length=700, blank=True, help_text='If given, ensures the job is only run on the server with the equivalent host name.<br/>Not setting any hostname will cause the job to be run on the first server that processes pending jobs.<br/> e.g. The hostname of this server is <b>7910f538ac86</b>.', null=True, verbose_name='target hostname'),
+            field=models.CharField(max_length=700, blank=True, help_text=chroniker.models.Job.hostname_help_text_setter, null=True, verbose_name='target hostname'),
         ),
         migrations.AlterField(
             model_name='job',

--- a/chroniker/migrations/0002_auto_20160517_1429.py
+++ b/chroniker/migrations/0002_auto_20160517_1429.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('chroniker', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='job',
+            name='frequency',
+            field=models.CharField(max_length=10, verbose_name='frequency', choices=[('YEARLY', 'Yearly'), ('MONTHLY', 'Monthly'), ('WEEKLY', 'Weekly'), ('DAILY', 'Daily'), ('HOURLY', 'Hourly'), ('MINUTELY', 'Minutely'), ('SECONDLY', 'Secondly')]),
+        ),
+        migrations.AlterField(
+            model_name='job',
+            name='hostname',
+            field=models.CharField(max_length=700, blank=True, help_text='If given, ensures the job is only run on the server with the equivalent host name.<br/>Not setting any hostname will cause the job to be run on the first server that processes pending jobs.<br/> e.g. The hostname of this server is <b>7910f538ac86</b>.', null=True, verbose_name='target hostname'),
+        ),
+        migrations.AlterField(
+            model_name='job',
+            name='maximum_log_entries',
+            field=models.PositiveIntegerField(help_text='The maximum number of most recent log entries to keep.<br/>A value of 0 keeps all log entries.', default=1000),
+        ),
+        migrations.AlterField(
+            model_name='job',
+            name='monitor_error_template',
+            field=models.TextField(help_text='If this is a monitor, this is the template used to compose the error text email.<br/>Available variables: {{ job }} {{ stderr }} {{ url }}', blank=True, default='\nThe monitor "{{ job.name }}" has indicated a problem.\n\nPlease review this monitor at {{ url }}\n\n{{ job.monitor_description_safe }}\n\n{{ stderr }}\n', null=True),
+        ),
+        migrations.AlterField(
+            model_name='jobdependency',
+            name='dependee',
+            field=models.ForeignKey(help_text='The thing that has other jobs waiting on it to complete.', related_name='dependents', to='chroniker.Job'),
+        ),
+        migrations.AlterField(
+            model_name='jobdependency',
+            name='dependent',
+            field=models.ForeignKey(help_text='The thing that cannot run until another job completes.', related_name='dependencies', to='chroniker.Job'),
+        ),
+        migrations.AlterField(
+            model_name='jobdependency',
+            name='wait_for_completion',
+            field=models.BooleanField(help_text='If checked, the dependent job will not run until the dependee job has completed.', default=True),
+        ),
+        migrations.AlterField(
+            model_name='jobdependency',
+            name='wait_for_next_run',
+            field=models.BooleanField(help_text='If checked, the dependent job will not run until the dependee job has a next_run greater than its next_run.', default=True),
+        ),
+        migrations.AlterField(
+            model_name='jobdependency',
+            name='wait_for_success',
+            field=models.BooleanField(help_text='If checked, the dependent job will not run until the dependee job has completed successfully.', default=True),
+        ),
+        migrations.AlterField(
+            model_name='log',
+            name='duration_seconds',
+            field=models.PositiveIntegerField(db_index=True, blank=True, editable=False, null=True, verbose_name='duration (total seconds)'),
+        ),
+    ]

--- a/chroniker/models.py
+++ b/chroniker/models.py
@@ -568,17 +568,20 @@ class Job(models.Model):
         help_text=_('''When non-zero, the job will be forcibly killed if
             running for more than this amount of time.'''))
     
+    def hostname_help_text_setter():
+        return _('If given, ensures the job is only run on the server ' + \
+                 'with the equivalent host name.<br/>Not setting any hostname ' + \
+                 'will cause the job to be run on the first server that ' + \
+                 'processes pending jobs.<br/> ' + \
+                 'e.g. The hostname of this server is <b>%s</b>.') \
+                 % socket.gethostname()
+
     hostname = models.CharField(
         max_length=700,
         blank=True,
         null=True,
         verbose_name='target hostname',
-        help_text=_('If given, ensures the job is only run on the server ' + \
-            'with the equivalent host name.<br/>Not setting any hostname ' + \
-            'will cause the job to be run on the first server that ' + \
-            'processes pending jobs.<br/> ' + \
-            'e.g. The hostname of this server is <b>%s</b>.') \
-            % socket.gethostname())
+        help_text=hostname_help_text_setter)
     
     current_hostname = models.CharField(
         max_length=700,


### PR DESCRIPTION
Recent changes to `models.py` are making Django complain:

> Your models have changes that are not yet reflected in a migration, and so won't be applied.

This is the migration that's automatically created by `manage.py makemigrations`, which brings the database up-to-date with the models. It looks like ~8 of the changes were made to remove byte literals, and the others were trivial changes (like setting `Blank=True`).

Please let me know if you have any questions, thank you!

Resolves #58 