### PR TITLE
Fixed passing of „update_heartbeat“ cron option

### DIFF
--- a/chroniker/management/commands/cron.py
+++ b/chroniker/management/commands/cron.py
@@ -59,7 +59,7 @@ class JobProcess(utils.TimedProcess):
         super(JobProcess, self).__init__(*args, **kwargs)
         self.job = job
 
-def run_job(job, update_heartbeat=None, **kwargs):
+def run_job(job, **kwargs):
     
     update_heartbeat = kwargs.pop('update_heartbeat', None)
     stdout_queue = kwargs.pop('stdout_queue', None)


### PR DESCRIPTION
_update_heartbeat_ would always be "None" when run via "cron" command, so all long running jobs would be killed when 5 minutes (default) have passed. 