### PR TITLE
Fix cron_clean command so it accepts arguments

### DIFF
--- a/chroniker/management/commands/cron_clean.py
+++ b/chroniker/management/commands/cron_clean.py
@@ -1,32 +1,21 @@
 from datetime import timedelta
-import sys
 
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
 from chroniker.models import Log
 
+
 class Command(BaseCommand):
     help = 'Deletes old job logs.'
 
+    def add_arguments(self, parser):
+        parser.add_argument('unit', choices=['minutes', 'hours', 'days', 'weeks'])
+        parser.add_argument('amount', type=int)
+
     def handle(self, *args, **options):
-
-        if len(args) != 2:
-            sys.stderr.write(
-                'Command requires two arguments. '
-                'Unit (weeks, days, hours or minutes) and interval.\n')
-            return
-
-        unit = str(args[0])
-        if unit not in ['weeks', 'days', 'hours', 'minutes']:
-            sys.stderr.write('Valid units are weeks, days, hours or minutes.\n')
-            return
-        try:
-            amount = int(args[1])
-        except ValueError:
-            sys.stderr.write('Interval must be an integer.\n')
-            return
-
+        unit = options['unit']
+        amount = options['amount']
         kwargs = {unit: amount}
         time_ago = timezone.now() - timedelta(**kwargs)
         Log.cleanup(time_ago)

--- a/chroniker/tests/management/commands/test_cron_clean.py
+++ b/chroniker/tests/management/commands/test_cron_clean.py
@@ -1,0 +1,10 @@
+from django.core.management import call_command
+from django.test import TestCase
+
+
+class CommandTest(TestCase):
+    def test_command_executes_successfully(self):
+        call_command('cron_clean', 'minutes', 1)
+        call_command('cron_clean', 'hours', 1)
+        call_command('cron_clean', 'days', 1)
+        call_command('cron_clean', 'weeks', 1)


### PR DESCRIPTION
The `cron_clean` command was not working. Probably it was programmed against old versions of Django which did not have a proper argument parsing for commands.