### PR TITLE
Allow Jobs to run on every server instance at once if hostname is "*"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,5 +61,3 @@ docs/_build/
 /site/
 /*.geany
 /*.out
-.vscode/
-chroniker/.venv/

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ docs/_build/
 /site/
 /*.geany
 /*.out
+.vscode/
+chroniker/.venv/

--- a/chroniker/__init__.py
+++ b/chroniker/__init__.py
@@ -1,2 +1,2 @@
-VERSION = (1, 0, 22)
+VERSION = (1, 0, 23)
 __version__ = '.'.join(map(str, VERSION))

--- a/chroniker/models.py
+++ b/chroniker/models.py
@@ -913,7 +913,7 @@ class Job(models.Model):
             if not self.dependencies_met():
                 # Note, this will cause the job to be re-checked the next time cron runs.
                 print('Job "{}" has unmet dependencies. Aborting run.'.format(self.name))
-            elif check_running and self.check_is_running():
+            elif check_running and self.check_is_running() and hostname != "*":
                 print('Job "{}" already running. Aborting run.'.format(self.name))
             elif not self.is_due(check_running=check_running):
                 print('Job "{}" not due. Aborting run.'.format(self.name))
@@ -1165,12 +1165,14 @@ class Job(models.Model):
             self.lock_file = ""
             self.save()
             return False
+
+        # We ignore is_running and hopefully the lockfile in line 987 or a pid check stops the job from running again
+        if self.hostname == "*":
+            return False
+
         # We assume the database record is definitive.
         return self.is_running
 
-        if self.hostname == "*":
-            # We ignore is_running and hopefully the lockfile in line 987 or a pid check stops the job from running again
-            return False
 
     check_is_running.short_description = "is running"
     check_is_running.boolean = True

--- a/chroniker/models.py
+++ b/chroniker/models.py
@@ -915,7 +915,7 @@ class Job(models.Model):
                 # Note, this will cause the job to be re-checked the next time cron runs.
                 print('Job "{}" has unmet dependencies. Aborting run.'.format(self.name))
             # Run an already running job if it's a wildcard job
-            elif check_running and self.check_is_running() and hostname != "*":
+            elif check_running and self.check_is_running() and self.hostname != "*":
                 print('Job "{}" already running. Aborting run.'.format(self.name))
             elif not self.is_due(check_running=check_running):
                 print('Job "{}" not due. Aborting run.'.format(self.name))
@@ -931,7 +931,6 @@ class Job(models.Model):
         Updates the record in the database to show it as running.
         Updates both the fields in the current instance as well as the fields in the database.
         """
-        # The "database lock" is just is_running!
         kwargs = dict(
             is_running=True,
             last_run_start_timestamp=timezone.now(),
@@ -987,7 +986,6 @@ class Job(models.Model):
                     # Fixes MySQL error "Commands out of sync"?
                     connection.close()
 
-                    # This doesn't check for CHRONIKER_CHECK_LOCK_FILE?
                     self.mark_running(lock_file=lock_file)
 
             except Exception as e:
@@ -1168,13 +1166,12 @@ class Job(models.Model):
             self.save()
             return False
 
-        # We ignore is_running and hopefully the lockfile in line 987 or a pid check stops the job from running again
-        if self.hostname == "*":
-            return False
+        # We already ignore is_running if hostname == * so this shouldn't be needed
+        # if self.hostname == "*":
+        #     return False
 
         # We assume the database record is definitive.
         return self.is_running
-
 
     check_is_running.short_description = "is running"
     check_is_running.boolean = True

--- a/chroniker/models.py
+++ b/chroniker/models.py
@@ -272,7 +272,8 @@ class JobManager(models.Manager):
             )
         q = q.filter(enabled=True)
         if check_running:
-            q = q.filter(is_running=False)
+            # Get jobs that aren't running and potentially-running every-host jobs
+            q = q.filter(Q(is_running=False) | Q(hostname="*"))
         if job is not None:
             if isinstance(job, int):
                 job = job.id

--- a/chroniker/models.py
+++ b/chroniker/models.py
@@ -914,6 +914,7 @@ class Job(models.Model):
             if not self.dependencies_met():
                 # Note, this will cause the job to be re-checked the next time cron runs.
                 print('Job "{}" has unmet dependencies. Aborting run.'.format(self.name))
+            # Run an already running job if it's a wildcard job
             elif check_running and self.check_is_running() and hostname != "*":
                 print('Job "{}" already running. Aborting run.'.format(self.name))
             elif not self.is_due(check_running=check_running):
@@ -1150,7 +1151,7 @@ class Job(models.Model):
         """
         This function actually checks to ensure that a job is running.
         """
-        if _settings.CHRONIKER_CHECK_LOCK_FILE and self.is_running and self.lock_file and self.hostname:
+        if _settings.CHRONIKER_CHECK_LOCK_FILE and self.is_running and self.lock_file:
             # The Job thinks that it is running, so lets actually check
             # NOTE: This will screw up the record if separate hosts
             # are processing and reading the jobs.


### PR DESCRIPTION
As per #216, this simple modification allows using `*` as a hostname to override the first-instance-available default behavior and run a Job on all servers. Only basic testing was conducted, but this seems to work as expected.

I'm aware that this is quick-and-dirty hack, please review it and let me know what can be done better :)
