### PR TITLE
Make cron work under the spawn and forkserver start methods

### DIFF
--- a/chroniker/management/commands/cron.py
+++ b/chroniker/management/commands/cron.py
@@ -9,12 +9,26 @@ from multiprocessing import Queue
 
 import psutil
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.db import connection
 from django.utils import timezone
 
-from chroniker import settings as _settings, utils
-from chroniker.models import Job, Log
+# Children created by the "spawn" and "forkserver" start methods are fresh
+# interpreters that don't inherit the parent's django.setup(). They import
+# this module to unpickle the Process object, which pulls in chroniker.models
+# and fails with AppRegistryNotReady unless the registry is already populated.
+# This has to happen at import time; anything later is too late. It is a no-op
+# in the parent and under "fork", where setup() has already run.
+# See issues #99, #208 and #397.
+import django
+from django.apps import apps as _django_apps
+
+if not _django_apps.ready: # pragma: no cover
+    django.setup()
+
+# These must follow the setup() call above, not precede it.
+from chroniker import settings as _settings, utils # pylint: disable=wrong-import-position
+from chroniker.models import Job, Log # pylint: disable=wrong-import-position
 
 
 def kill_stalled_processes(dryrun=True):
@@ -213,6 +227,7 @@ def run_cron(jobs=None, **kwargs):
 
         if not dryrun:
             print("%d Jobs are due." % len(procs))
+            failed_procs = []
 
             # Wait for all job processes to complete.
             while procs:
@@ -230,6 +245,35 @@ def run_cron(jobs=None, **kwargs):
                     if not proc.is_alive():
                         print('Process %s ended.' % (proc,))
                         procs.remove(proc)
+
+                        # A child that dies before it can record its own log
+                        # row, e.g. on an import error, is otherwise
+                        # indistinguishable here from one that completed, and
+                        # cron would report success. See issue #397.
+                        if proc.exitcode:
+                            failed_procs.append(proc)
+                            print('Process %s exited with code %s.' % (proc, proc.exitcode), file=sys.stderr)
+                            connection.close()
+                            Job.objects.update()
+                            j = Job.objects.get(id=proc.job.id)
+                            if not Log.objects.filter(job=j, run_start_datetime=j.last_run_start_timestamp).exists():
+                                # The child never got far enough to log, so
+                                # record the failure on its behalf.
+                                Log.objects.create(
+                                    job=proc.job,
+                                    run_start_datetime=j.last_run_start_timestamp or timezone.now(),
+                                    run_end_datetime=timezone.now(),
+                                    success=False,
+                                    on_time=False,
+                                    hostname=socket.gethostname(),
+                                    stdout=''.join(stdout_map[proc.pid]),
+                                    stderr=''.join(stderr_map[proc.pid] + ['Job process exited with code %s\n' % proc.exitcode]),
+                                )
+                            proc.job.is_running = False
+                            proc.job.force_run = False
+                            proc.job.force_stop = False
+                            proc.job.last_run_successful = False
+                            proc.job.save()
                     elif proc.is_expired:
                         print('Process %s expired.' % (proc,))
                         proc_id = proc.pid
@@ -261,7 +305,15 @@ def run_cron(jobs=None, **kwargs):
 
                 time.sleep(1)
             print('!' * 80)
-            print('All jobs complete!')
+            if failed_procs:
+                print(
+                    '%d of the job processes failed: %s' % (len(failed_procs), ', '.join(str(_p) for _p in failed_procs)),
+                    file=sys.stderr,
+                )
+            else:
+                print('All jobs complete!')
+            return len(failed_procs)
+        return 0
     finally:
         if _settings.CHRONIKER_USE_PID and os.path.isfile(pid_fn) and clear_pid:
             os.unlink(pid_fn)
@@ -293,10 +345,16 @@ class Command(BaseCommand):
         # Find specific job ids to run, if any.
         jobs = [int(_.strip()) for _ in options.get('jobs', '').strip().split(',') if _.strip().isdigit()]
 
-        run_cron(
+        failures = run_cron(
             jobs,
             update_heartbeat=int(options['update_heartbeat']),
             force_run=options['force_run'],
             dryrun=options['dryrun'],
             sync=options['sync'],
         )
+
+        # Exit non-zero so a supervisor or systemd timer sees the failure.
+        # Without this, a job process that dies without running is reported
+        # as a clean run. See issue #397.
+        if failures:
+            raise CommandError('%d job process(es) failed.' % failures)

--- a/chroniker/tests/tests.py
+++ b/chroniker/tests/tests.py
@@ -6,7 +6,9 @@ Quick run with:
 """
 from __future__ import print_function
 
+import multiprocessing
 import os
+import pickle
 import socket
 import sys
 import tempfile
@@ -35,6 +37,7 @@ from django.test.client import Client
 from django.utils import timezone
 
 from chroniker import constants as c, settings as _settings, utils
+from chroniker.management.commands import cron as chroniker_cron
 from chroniker.models import Job, Log
 
 warnings.simplefilter('error', RuntimeWarning)
@@ -817,3 +820,91 @@ class JobTestCase(TestCase):
         )
         self.assertIn(job.id, [j.id for j in Job.objects.due(job=job.id)])
         self.assertIn(job.id, [j.id for j in Job.objects.due(job=job)])
+
+    def test_timed_process_is_picklable(self):
+        """
+        Confirm a TimedProcess can be serialized for the spawn/forkserver
+        start methods.
+
+        These pickle the Process object to reach the child, so an open stream
+        stored on the instance makes every job unstartable. Python 3.14 made
+        forkserver the default on Linux, so this stopped being an edge case.
+        See issues #99, #208 and #397.
+        """
+        proc = utils.TimedProcess(max_seconds=10)
+
+        # The stream must not be held on the instance...
+        self.assertIsNone(proc.__dict__.get('_fout'))
+        # ...but must still resolve for the parent, which does the printing.
+        self.assertTrue(hasattr(proc.fout, 'write'))
+
+        # __getstate__ is what spawn/forkserver hand to the child. No open
+        # stream may survive it, whether or not one was supplied explicitly.
+        # (The Process object as a whole is never pickled directly here;
+        # multiprocessing blocks that for any Process, so the state dict is
+        # what we can meaningfully assert on.)
+        for supplied in (None, sys.stderr):
+            p = utils.TimedProcess(max_seconds=10, fout=supplied)
+            state = p.__getstate__()
+            self.assertIsNone(state['_fout'])
+            self.assertIsNone(state['_p'])
+            # Every remaining value must survive a round trip; an open stream
+            # here is exactly what used to break spawn.
+            for key, value in state.items():
+                if key == '_config':
+                    # multiprocessing's own bookkeeping, never our concern.
+                    continue
+                try:
+                    pickle.dumps(value)
+                except Exception as exc: # pylint: disable=broad-except
+                    self.fail('TimedProcess state %r is not picklable: %s' % (key, exc))
+
+    def test_cron_reports_failed_job_process(self):
+        """
+        Confirm cron notices a job process that dies without running.
+
+        The wait loop used to check only is_alive(), so a child that died on
+        import was indistinguishable from one that finished: cron printed
+        'All jobs complete!' and exited 0, leaving jobs silently un-run under
+        a supervisor or systemd timer. See issue #397.
+        """
+
+        # This test monkeypatches the process target, which means the target
+        # has to reach the child through inheritance rather than pickling: a
+        # local function can't be pickled, and a module-level one wouldn't help
+        # either, since a spawned child re-imports the unpatched module and
+        # never sees the patch. Defect 3 is start-method-independent, so pin
+        # fork for the duration and lose nothing. Reported by @tclancy, who hit
+        # this on macOS where spawn is the default.
+        original_start_method = multiprocessing.get_start_method(allow_none=True)
+        multiprocessing.set_start_method('fork', force=True)
+        if original_start_method:
+            self.addCleanup(multiprocessing.set_start_method, original_start_method, force=True)
+
+        job = Job.objects.create(
+            name="Test Job That Dies",
+            raw_command="true",
+            enabled=True,
+            next_run=timezone.now() - timedelta(days=1),
+        )
+
+        # Force the job process to die before it can record a log row, which
+        # is what an import error in a spawned child looks like from here.
+        original_run_job = chroniker_cron.run_job
+
+        def die_immediately(*args, **kwargs):
+            os._exit(1) # pylint: disable=protected-access
+
+        chroniker_cron.run_job = die_immediately
+        try:
+            failures = chroniker_cron.run_cron([job.id], update_heartbeat=0, force_run=True)
+        finally:
+            chroniker_cron.run_job = original_run_job
+
+        self.assertEqual(failures, 1)
+
+        job.refresh_from_db()
+        self.assertEqual(job.last_run_successful, False)
+        self.assertFalse(job.is_running)
+        # A failure that produced no log of its own must still be recorded.
+        self.assertTrue(Log.objects.filter(job=job, success=False).exists())

--- a/chroniker/utils.py
+++ b/chroniker/utils.py
@@ -17,7 +17,6 @@ except ImportError:
 import psutil
 
 from django.conf import settings
-from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db import connection
 from django.urls import reverse
@@ -61,12 +60,17 @@ def get_remaining_seconds(*args, **kwargs):
 
 
 def get_admin_change_url(obj):
+    # Imported lazily. A module-scope model import makes this module
+    # unimportable until the app registry is ready, which breaks
+    # spawn/forkserver children as they unpickle. See issue #397.
+    from django.contrib.contenttypes.models import ContentType # pylint: disable=import-outside-toplevel
     ct = ContentType.objects.get_for_model(obj)
     change_url_name = 'admin:%s_%s_change' % (ct.app_label, ct.model)
     return reverse(change_url_name, args=(obj.id,))
 
 
 def get_admin_changelist_url(obj):
+    from django.contrib.contenttypes.models import ContentType # pylint: disable=import-outside-toplevel
     ct = ContentType.objects.get_for_model(obj)
     list_url_name = 'admin:%s_%s_changelist' % (ct.app_label, ct.model)
     return reverse(list_url_name)
@@ -275,7 +279,12 @@ class TimedProcess(Process):
 
     def __init__(self, max_seconds, time_type=c.MAX_TIME, fout=None, check_freq=1, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fout = fout or sys.stdout
+        # Deliberately not falling back to sys.stdout here. The "spawn" and
+        # "forkserver" start methods pickle the Process object to reach the
+        # child, and an open stream can't be pickled, so storing one makes the
+        # process unstartable. Resolved lazily in the fout property instead.
+        # See issues #99, #208 and #397.
+        self._fout = fout
         self.t0 = time.process_time()
         self.t0_objective = time.time()
         self.max_seconds = float(max_seconds)
@@ -287,6 +296,29 @@ class TimedProcess(Process):
         self._p = None
         self._process_times = {} # {pid:user_seconds}
         self._last_duration_seconds = None
+
+    def __getstate__(self):
+        # An explicitly-supplied stream still can't be pickled, and fout is
+        # only ever read in the parent, so drop it when handing state to a
+        # spawn/forkserver child rather than letting start() fail.
+        state = self.__dict__.copy()
+        state['_fout'] = None
+        state['_p'] = None
+        return state
+
+    @property
+    def fout(self):
+        """
+        The stream progress messages are written to.
+
+        Resolved on access rather than stored, so the instance stays
+        picklable for spawn/forkserver. Only ever read in the parent.
+        """
+        return self._fout or sys.stdout
+
+    @fout.setter
+    def fout(self, value):
+        self._fout = value
 
     def terminate(self, sig=15, *args, **kwargs):
         """


### PR DESCRIPTION
Fixes #397
Fixes #208
Fixes #99

`manage.py cron` cannot run a job under the `spawn` or `forkserver` start methods. That has always been true, but **Python 3.14 changed the default start method on Linux from `fork` to `forkserver`**, so on 3.14 the scheduler fails on every invocation out of the box. macOS (spawn by default since 3.8) and Windows (spawn only) have been hitting this for years — that is what #208 and #99 report, with the same `cannot pickle '_io.TextIOWrapper'` signature.

Full credit to @tclancy for the diagnosis in #397; the analysis there was accurate on every point, including that fixing defect 1 alone makes things worse.

> **Note:** this PR targets `deps/upgrade-test-tooling-py39` (#398), not `master`, so the diff stays focused. Merge #398 first and this will rebase onto master cleanly.

## The three defects

**1. `TimedProcess` stored an open stream.** `self.fout = fout or sys.stdout` meant every instance held a `TextIOWrapper`. spawn/forkserver pickle the `Process` to reach the child:

```
TypeError: cannot pickle '_io.TextIOWrapper' object
```

`fout` is only ever read in the parent, so it is now resolved lazily in a property, and `__getstate__` drops it (along with the cached psutil handle) for the child. An explicitly-supplied stream is handled too, not just the `sys.stdout` default.

**2. The child never set Django up.** spawn/forkserver children are fresh interpreters that don't inherit `django.setup()`. The child imports `cron.py` to unpickle the Process, which pulls in `chroniker.models`, so it died with `AppRegistryNotReady` before reaching any of our code:

```
django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
```

`setup()` now runs at module import, ahead of the model imports — the only point early enough to help. It's a no-op in the parent and under `fork`. `chroniker/utils.py` imported `ContentType` at module scope for the same reason and had to be deferred into the two functions that use it.

**3. `run_cron` reported success when a job process died.** This is the serious one, and it's independent of Python version. The wait loop checked only `proc.is_alive()` and never inspected `exitcode`, so a child that died immediately was indistinguishable from one that finished:

```
Process <JobProcess ... exitcode=1> ended.
All jobs complete!
   job.last_run: None
   log rows: 0
```

A non-zero exitcode now marks the job unsuccessful, records a `Log` row if the child died before writing its own, and makes `cron` exit non-zero via `CommandError`.

## Behaviour change worth flagging

Defect 3's fix means **a deployment whose jobs have been failing silently will start reporting failure** — `cron` will exit non-zero where it previously exited 0. That is the entire point (under a systemd timer the old behaviour is invisible), but it will surface pre-existing breakage in places that looked healthy, so it may deserve a note in the release notes.

If you'd rather ship the pickling fix alone first, I can split defect 3 into its own PR — but as filed in #397, fixing 1 and 2 without 3 converts a visible crash into a silent no-op, which is why they're together here.

## Tests

Two regression tests, both confirmed to **fail without the corresponding fix** and pass with it:

- `test_timed_process_is_picklable` — no open stream survives `__getstate__`, whether or not one was supplied.
- `test_cron_reports_failed_job_process` — a child that dies without logging yields `run_cron() == 1`, `last_run_successful=False`, and a `Log` row. Against unfixed code this fails with `AssertionError: None != 1`, i.e. the silent success.

## Verification

Locally on **3.10** and **3.12**: pylint **10.00/10** (exit 0) and **20/20** tests passing (18 existing + 2 new).
