### PR TITLE
Stop the admin "is due" column depending on the viewing host

### DIFF
--- a/chroniker/admin.py
+++ b/chroniker/admin.py
@@ -98,7 +98,7 @@ class JobAdmin(admin.ModelAdmin):
         'current_hostname',
         'current_pid',
         'job_type',
-        'is_due',
+        'is_due_display',
     )
     list_display_links = ('name',)
     list_filter = (
@@ -128,7 +128,7 @@ class JobAdmin(admin.ModelAdmin):
                 'classes': ('wide',),
                 'fields': (
                     'is_running',
-                    'is_due',
+                    'is_due_display',
                     'is_fresh',
                     'last_run_successful',
                     'total_parts',

--- a/chroniker/models.py
+++ b/chroniker/models.py
@@ -247,12 +247,17 @@ class JobManager(models.Manager):
         kwargs = dict((_name, _value) for _name, _value in zip(_settings.CHRONIKER_JOB_NK, args))
         return self.get(**kwargs)
 
-    def due(self, job=None, check_running=True):
+    def due(self, job=None, check_running=True, check_hostname=True):
         """
         Returns a ``QuerySet`` of all jobs waiting to be run.  NOTE: this may
         return ``Job``s that are still currently running; it is your
         responsibility to call ``Job.check_is_running()`` to determine whether
         or not the ``Job`` actually needs to be run.
+
+        Set ``check_hostname=False`` to ignore the target hostname. That is
+        only appropriate for display, such as the admin's "is due" column,
+        where the question is whether the job is due at all rather than
+        whether this particular host should run it. See issue #128.
         """
 
         # Lock the Job record if possible with the backend.
@@ -265,20 +270,20 @@ class JobManager(models.Manager):
         else:
             q = self.all()
         q = q.filter(Q(next_run__lte=timezone.now()) | Q(force_run=True))
-        q = q.filter(
-            Q(hostname__isnull=True) | \
-            Q(hostname='') | \
-            Q(hostname=socket.gethostname()) | \
-            Q(hostname='*')
-            )
+        if check_hostname:
+            q = q.filter(
+                Q(hostname__isnull=True) | \
+                Q(hostname='') | \
+                Q(hostname=socket.gethostname()) | \
+                Q(hostname='*')
+                )
         q = q.filter(enabled=True)
         if check_running:
             # Get jobs that aren't running and potentially-running every-host jobs
             q = q.filter(Q(is_running=False) | Q(hostname="*"))
         if job is not None:
-            if isinstance(job, int):
-                job = job.id
-            q = q.filter(id=job.id)
+            # Accept either a Job or a raw id.
+            q = q.filter(id=job if isinstance(job, int) else job.id)
         return q
 
     def due_with_met_dependencies(self, jobs=None):
@@ -911,6 +916,20 @@ class Job(models.Model):
         return res
 
     is_due.boolean = True
+
+    def is_due_display(self):
+        """
+        Whether the job is due, ignoring the target hostname.
+
+        The admin may well be served from a different host than the one
+        running the jobs, in which case the hostname filter in due() makes
+        this column read False for every job targeting the cron host. For
+        display the hostname is not the interesting part. See issue #128.
+        """
+        return self.is_due(check_hostname=False)
+
+    is_due_display.boolean = True
+    is_due_display.short_description = _('is due')
 
     def is_due_with_dependencies_met(self, running_ids=None):
         """

--- a/chroniker/tests/tests.py
+++ b/chroniker/tests/tests.py
@@ -762,3 +762,58 @@ class JobTestCase(TestCase):
 
         # Empty args must not raise.
         self.assertEqual(Job(args='').get_args(), ([], {}))
+    def test_is_due_display_ignores_hostname(self):
+        """
+        Confirm the admin's "is due" column ignores the target hostname.
+
+        due() filters on socket.gethostname() so the scheduler only picks up
+        jobs meant for this host. When the admin is served from a different
+        host than the cron runner, that made the column read False for every
+        job targeting the cron host. See issue #128.
+        """
+        job = Job.objects.create(
+            name="Test Job For Another Host",
+            raw_command="true",
+            enabled=True,
+            hostname='some-other-host.example.com',
+            next_run=timezone.now() - timedelta(days=1),
+        )
+
+        # The scheduler must still skip it; this host is not the target.
+        self.assertFalse(job.is_due())
+        self.assertNotIn(job.id, [j.id for j in Job.objects.due()])
+
+        # ...but the admin column reports it as due, which it is.
+        self.assertTrue(job.is_due_display())
+
+        # A job targeting no particular host is due either way.
+        local_job = Job.objects.create(
+            name="Test Job For Any Host",
+            raw_command="true",
+            enabled=True,
+            hostname='',
+            next_run=timezone.now() - timedelta(days=1),
+        )
+        self.assertTrue(local_job.is_due())
+        self.assertTrue(local_job.is_due_display())
+
+        # A disabled job is due under neither.
+        job.enabled = False
+        job.save()
+        self.assertFalse(job.is_due_display())
+
+    def test_due_accepts_job_id(self):
+        """
+        Confirm due() accepts a raw id as well as a Job instance.
+
+        The isinstance check was inverted, so passing an int raised
+        AttributeError: 'int' object has no attribute 'id'.
+        """
+        job = Job.objects.create(
+            name="Test Job By Id",
+            raw_command="true",
+            enabled=True,
+            next_run=timezone.now() - timedelta(days=1),
+        )
+        self.assertIn(job.id, [j.id for j in Job.objects.due(job=job.id)])
+        self.assertIn(job.id, [j.id for j in Job.objects.due(job=job)])


### PR DESCRIPTION
Fixes #128

> **Note:** targets `deps/upgrade-test-tooling-py39` (#398) rather than `master`, so the diff stays focused. Merge #398 first and this rebases onto master cleanly.

## The problem

`Job.objects.due()` filters on `socket.gethostname()` so the scheduler only picks up jobs meant for the host it is running on:

```python
q = q.filter(
    Q(hostname__isnull=True) | Q(hostname='') |
    Q(hostname=socket.gethostname()) | Q(hostname='*')
)
```

`is_due()` goes through that same queryset, and the admin renders it as a column. So when the admin is served from a different machine than the cron runner — which is the normal setup for anything non-trivial — every job with a target hostname reads **"is due: False"** no matter how overdue it is.

## The fix

The hostname is not the interesting part when the question is "is this job due?" for display. `due()` takes a new `check_hostname` argument, and the admin now calls `is_due_display()`, which passes `check_hostname=False`.

**Scheduling behaviour is unchanged** — `due()` still filters by hostname by default, and `is_due()` itself is untouched. Only the two admin display sites changed.

## Drive-by fix

The same method had an inverted `isinstance` check:

```python
if isinstance(job, int):
    job = job.id          # an int has no .id
q = q.filter(id=job.id)
```

Passing an id raised `AttributeError: 'int' object has no attribute 'id'`. Unreachable today, since the only caller passes `job=self`, but wrong either way, and the docstring implies an id is acceptable.

## Tests

Two regression tests, both confirmed to **fail without the fix**:

- `test_is_due_display_ignores_hostname` — a job targeting another host is excluded from `due()` and `is_due()`, but `is_due_display()` reports it as due; a disabled job is due under neither. Fails with `AttributeError: 'Job' object has no attribute 'is_due_display'`.
- `test_due_accepts_job_id` — `due()` accepts both a `Job` and a raw id. Fails with `AttributeError: 'int' object has no attribute 'id'`.

## Verification

Locally on 3.10: pylint **10.00/10** (exit 0) and **20/20** tests passing.
