### PR TITLE
Respect quoted strings in job arguments

### DIFF
--- a/chroniker/models.py
+++ b/chroniker/models.py
@@ -863,15 +863,22 @@ class Job(models.Model):
         Processes the args and returns a tuple or (args, options) for passing
         to ``call_command``.
 
+        Splits with shlex, so quoted values survive as a single argument and
+        the quotes themselves are stripped, matching how raw_command is
+        already handled. See issue #138.
+
         >>> job = Job(args="arg1 arg2 kwarg1='some value'")
         >>> job.get_args()
-        (['arg1', 'arg2', "value'"], {'kwarg1': "'some"})
+        (['arg1', 'arg2'], {'kwarg1': 'some value'})
+
+        >>> job = Job(args='arg1 kwarg1="a=b" kwarg2=plain')
+        >>> job.get_args()
+        (['arg1'], {'kwarg1': 'a=b', 'kwarg2': 'plain'})
         """
         args = []
         options = {}
-        for arg in self.args.split():
+        for arg in shlex.split(self.args or ''):
             if arg.find('=') > -1:
-                #key, value = arg.split('=')
                 parts = arg.split('=')
                 key = parts[0]
                 value = '='.join(parts[1:])

--- a/chroniker/tests/tests.py
+++ b/chroniker/tests/tests.py
@@ -729,3 +729,36 @@ class JobTestCase(TestCase):
 
         job.refresh_from_db()
         self.assertEqual(job.last_run_successful, True)
+
+    def test_get_args_handles_quoted_strings(self):
+        """
+        Confirm quoted argument values survive as a single argument.
+
+        args was split on whitespace, so arg="this is a string" became three
+        arguments with the quotes left embedded in the values. See issue #138.
+        """
+        job = Job(args="arg1 arg2 kwarg1='some value'")
+        args, options = job.get_args()
+        self.assertEqual(args, ['arg1', 'arg2'])
+        self.assertEqual(options, {'kwarg1': 'some value'})
+
+        # Double quotes, and an '=' inside a quoted value.
+        job = Job(args='arg1 kwarg1="a=b" kwarg2=plain')
+        args, options = job.get_args()
+        self.assertEqual(args, ['arg1'])
+        self.assertEqual(options, {'kwarg1': 'a=b', 'kwarg2': 'plain'})
+
+        # A quoted positional argument.
+        job = Job(args='"two words" other')
+        args, options = job.get_args()
+        self.assertEqual(args, ['two words', 'other'])
+        self.assertEqual(options, {})
+
+        # Unquoted args behave exactly as before.
+        job = Job(args='a b key=value')
+        args, options = job.get_args()
+        self.assertEqual(args, ['a', 'b'])
+        self.assertEqual(options, {'key': 'value'})
+
+        # Empty args must not raise.
+        self.assertEqual(Job(args='').get_args(), ([], {}))


### PR DESCRIPTION
Fixes #138

> **Note:** targets `deps/upgrade-test-tooling-py39` (#398) rather than `master`, so the diff stays focused.

## The problem

`Job.get_args()` split the `args` field on plain whitespace, so a quoted value was torn into separate arguments and the quote characters were left embedded in whatever survived. The old docstring recorded the damage as if it were intended:

```python
>>> job = Job(args="arg1 arg2 kwarg1='some value'")
>>> job.get_args()
(['arg1', 'arg2', "value'"], {'kwarg1': "'some"})
```

So `kwarg1` came through as `'some` and `value'` became a stray positional argument.

## The fix

Split with `shlex` instead, which keeps a quoted value in one piece and strips the quotes:

```python
>>> job.get_args()
(['arg1', 'arg2'], {'kwarg1': 'some value'})
```

`raw_command` is **already** run through `shlex.split()` a few lines away, so this makes the two paths consistent rather than introducing a new dependency or a new convention. Args with no quoting are unaffected.

## Tests

`test_get_args_handles_quoted_strings` covers single quotes, double quotes, an `=` inside a quoted value, quoted positional arguments, the plain unquoted case, and empty args. Against the unfixed code it fails with:

```
AssertionError: Lists differ: ['arg1', 'arg2', "value'"] != ['arg1', 'arg2']
```

## Verification

Locally on 3.10: pylint **10.00/10** (exit 0) and **19/19** tests passing.
