### PR TITLE
Add a LICENSE file and state the license unambiguously

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2012-2026, Chris Spencer
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,8 @@
 recursive-include chroniker/templates *
 recursive-include chroniker/static *
 recursive-include chroniker/tests/fixtures *
+include LICENSE
+include README.md
 include requirements-min-django.txt
 include requirements.txt
 include requirements-test.txt

--- a/setup.py
+++ b/setup.py
@@ -43,14 +43,13 @@ setup(
     description="Easily control cron jobs via Django's admin.",
     long_description=long_description,
     long_description_content_type='text/markdown',
-    license="BSD",
+    license="BSD-3-Clause",
     url="https://github.com/chrisspen/django-chroniker",
     #https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         'Development Status :: 6 - Mature',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
Fixes #210

> **Note:** targets `deps/upgrade-test-tooling-py39` (#398) rather than `master`, so the diff stays focused.

`setup.py` claimed `"BSD"` with no LICENSE file in the repository. "BSD" doesn't identify a license on its own — it covers at least the 2-clause and 3-clause variants — and the text of each carries a copyright line specific to the project. That left @jayvdb unable to complete openSUSE packaging.

## Changes

- **`LICENSE`** — BSD 3-Clause text, the variant Django itself uses, with a copyright line covering the project from its first commit in 2012.
- **`setup.py`** — `license="BSD-3-Clause"`, a valid SPDX expression. Dropped the `'License :: OSI Approved :: BSD License'` classifier, since setuptools now deprecates license classifiers in favour of SPDX and warns about them during a build:
  ```
  SetuptoolsDeprecationWarning: License classifiers are deprecated.
  Please consider removing the following classifiers in favor of a SPDX license expression
  ```
- **`MANIFEST.in`** — did not include `LICENSE`, so it would not have reached the sdist even once written. Now includes `LICENSE` and `README.md`.

## Verification

Built the sdist and confirmed the file is actually in it, rather than assuming `MANIFEST.in` did its job:

```
$ tar tzf dist/django_chroniker-1.0.24.tar.gz | grep LICENSE
django_chroniker-1.0.24/LICENSE
```

The setuptools deprecation warning is also gone. pylint **10.00/10**.

**This is a legal statement about your own work, so please confirm BSD 3-Clause is what you intend before merging** — I picked it as the most common reading of "BSD" in the Django ecosystem, but 2-Clause would be an equally legitimate interpretation of what setup.py has said until now.
