### PR TITLE
Capture logging-module output in job logs

### DIFF
--- a/chroniker/models.py
+++ b/chroniker/models.py
@@ -994,6 +994,22 @@ class Job(models.Model):
         sys.stdout = stdout
         sys.stderr = stderr
 
+        # Swapping sys.stdout is not enough to capture the logging module.
+        # Handlers configured via settings.LOGGING hold a reference to whatever
+        # stream was current when they were built, which is the real stdout,
+        # long before this runs. So logger.info() bypasses the tee entirely and
+        # only print() ends up in the job log. Attach a handler bound to the
+        # tee for the duration of the run. See issue #13.
+        log_handler = logging.StreamHandler(stdout)
+        log_handler.setFormatter(logging.Formatter(_settings.CHRONIKER_LOG_FORMAT))
+        root_logger = logging.getLogger()
+        root_logger.addHandler(log_handler)
+        # A root logger left at its default WARNING would drop the info and
+        # debug calls this is meant to capture.
+        original_root_level = root_logger.level
+        if original_root_level > logging.INFO or original_root_level == logging.NOTSET:
+            root_logger.setLevel(logging.INFO)
+
         try:
             args, options = self.get_args()
 
@@ -1093,6 +1109,12 @@ class Job(models.Model):
                 print(t.render(ctx), file=sys.stderr)
 
         finally:
+            # Detach before the clone check below, so the early return can't
+            # leave the handler attached to the root logger.
+            root_logger.removeHandler(log_handler)
+            root_logger.setLevel(original_root_level)
+            log_handler.close()
+
             if original_pid != os.getpid():
                 # We're a clone of the parent job, so exit immediately
                 # so we don't conflict.

--- a/chroniker/settings.py
+++ b/chroniker/settings.py
@@ -66,3 +66,8 @@ CHRONIKER_AUTO_END_STALE_JOBS = settings.CHRONIKER_AUTO_END_STALE_JOBS = getattr
 CHRONIKER_JOB_NK = settings.CHRONIKER_JOB_NK = getattr(settings, 'CHRONIKER_JOB_NK', ('name',))
 
 CHRONIKER_JOB_ERROR_CALLBACK = settings.CHRONIKER_JOB_ERROR_CALLBACK = getattr(settings, 'CHRONIKER_JOB_ERROR_CALLBACK', None)
+
+# Format used for logging-module records captured into a job's log. Only
+# applies to records captured while a job runs; it does not affect any handler
+# configured in settings.LOGGING. See issue #13.
+CHRONIKER_LOG_FORMAT = settings.CHRONIKER_LOG_FORMAT = getattr(settings, 'CHRONIKER_LOG_FORMAT', '%(levelname)s %(name)s %(message)s')

--- a/chroniker/tests/management/commands/test_logger.py
+++ b/chroniker/tests/management/commands/test_logger.py
@@ -1,0 +1,14 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = 'Emits records through the logging module, for testing log capture.'
+
+    def handle(self, *args, **options):
+        print('printed line')
+        logger.info('logged info line')
+        logger.warning('logged warning line')

--- a/chroniker/tests/tests.py
+++ b/chroniker/tests/tests.py
@@ -6,6 +6,7 @@ Quick run with:
 """
 from __future__ import print_function
 
+import logging
 import os
 import socket
 import sys
@@ -762,3 +763,55 @@ class JobTestCase(TestCase):
 
         # Empty args must not raise.
         self.assertEqual(Job(args='').get_args(), ([], {}))
+
+    def test_logging_module_output_is_captured(self):
+        """
+        Confirm records emitted through the logging module reach the job log.
+
+        The job log is captured by swapping sys.stdout, but handlers built
+        from settings.LOGGING hold a reference to the stream that was current
+        when they were configured, which is the real stdout. So logger.info()
+        bypassed the capture entirely and only print() showed up in the log.
+        See issue #13.
+        """
+        job = Job.objects.create(
+            name="Test Job That Logs",
+            command="test_logger",
+            enabled=True,
+            log_stdout=True,
+            log_stderr=True,
+            next_run=timezone.now() - timedelta(days=1),
+        )
+
+        job.run(update_heartbeat=0)
+
+        log = Log.objects.filter(job=job).order_by('-id').first()
+        self.assertIsNotNone(log)
+
+        # print() has always worked; it is the control.
+        self.assertIn('printed line', log.stdout)
+        # These are what issue #13 reported missing.
+        self.assertIn('logged info line', log.stdout)
+        self.assertIn('logged warning line', log.stdout)
+
+    def test_logging_capture_restores_root_logger(self):
+        """
+        Confirm the temporary handler and level are removed after a run.
+
+        Leaving either in place would send every subsequent log record in the
+        process into a closed stream belonging to a finished job. See #13.
+        """
+        root_logger = logging.getLogger()
+        handlers_before = list(root_logger.handlers)
+        level_before = root_logger.level
+
+        job = Job.objects.create(
+            name="Test Job That Logs And Restores",
+            command="test_logger",
+            enabled=True,
+            next_run=timezone.now() - timedelta(days=1),
+        )
+        job.run(update_heartbeat=0)
+
+        self.assertEqual(list(root_logger.handlers), handlers_before)
+        self.assertEqual(root_logger.level, level_before)


### PR DESCRIPTION
Fixes #13

Reported in 2014 by @lukaszbanasiak, confirmed since by @steffenmandrup and @noisy.

## The problem

A job's output is captured by swapping `sys.stdout`/`sys.stderr` for a tee. That catches `print()`, but **not** the logging module — handlers built from `settings.LOGGING` hold a reference to whichever stream was current *when they were configured*, which is the real stdout, established long before any job runs.

Demonstrated in isolation:

```python
handler = logging.StreamHandler(sys.stdout)   # binds the CURRENT stdout
...
sys.stdout = captured                          # what chroniker does
print("printed line")                          # -> captured
log.info("logged line")                        # -> real stdout, escapes
```
```
CAPTURED CONTAINS: 'printed line\n'
-> 'logged line' captured? False
```

That is exactly the reported symptom: "There are only entries that use `print` syntax."

## The fix

Attach a `StreamHandler` bound to the tee to the root logger for the duration of a run, then remove it.

The root logger's level is raised to INFO for the run if it was higher — a default of WARNING would drop the very `logger.info()`/`logger.debug()` calls this is meant to capture — and the original level is restored afterwards.

Both the handler removal and the level restore happen in the `finally` block **ahead of the early `return` taken by a forked clone**, so neither can leak into the rest of the process. A leaked handler would send every subsequent record in the process into a closed stream belonging to a finished job.

Format is configurable via `CHRONIKER_LOG_FORMAT` (default `"%(levelname)s %(name)s %(message)s"`). This affects **only** records captured while a job runs — handlers configured in `settings.LOGGING` are untouched, so a project's own logging setup keeps working exactly as before.

## Tests

Adds a `test_logger` management command and two tests, both confirmed to **fail without the fix**:

- `test_logging_module_output_is_captured` — `print()` output serves as the control; the `logger.info()`/`logger.warning()` assertions are what #13 reported missing. Against unfixed code:
  ```
  AssertionError: 'logged info line' not found in "printed line\nDetermining 'next_run'..."
  ```
- `test_logging_capture_restores_root_logger` — the root logger's handlers and level are identical before and after a run.

## Verification

Locally on 3.10: pylint **10.00/10** (exit 0) and **21/21** tests passing.
