### PR TITLE
Pass values as arguments to format_html

### DIFF
--- a/chroniker/admin.py
+++ b/chroniker/admin.py
@@ -13,6 +13,7 @@ from django.utils import dateformat, timezone
 from django.utils.datastructures import MultiValueDict
 from django.utils.formats import get_format
 from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 from django.utils.text import capfirst
 try:
     from django.utils.translation import gettext_lazy as _
@@ -226,7 +227,7 @@ class JobAdmin(admin.ModelAdmin):
             except NoReverseMatch:
                 # New way
                 u = reverse('admin:chroniker_log_change', args=(log_id,))
-            return format_html('<a href="%s">%s</a>' % (u, value))
+            return format_html('<a href="{}">{}</a>', u, value)
         except Exception:
             return value
 
@@ -250,7 +251,7 @@ class JobAdmin(admin.ModelAdmin):
         dt = obj.next_run
         dt = utils.localtime(dt)
         value = capfirst(dateformat.format(dt, fmt))
-        return format_html("%s<br /><span class='mini'>(%s)</span>" % (value, obj.get_timeuntil()))
+        return format_html("{}<br /><span class='mini'>({})</span>", value, obj.get_timeuntil())
 
     get_timeuntil.admin_order_field = 'next_run'
     get_timeuntil.allow_tags = True
@@ -270,8 +271,7 @@ class JobAdmin(admin.ModelAdmin):
     def run_button(self, obj=None):
         if not obj or not obj.id:
             return ''
-        kwargs = dict(url='%d/run/?inline=1' % obj.id,)
-        return format_html('<a href="{url}" class="button">Run</a>'.format(**kwargs))
+        return format_html('<a href="{}" class="button">Run</a>', '%d/run/?inline=1' % obj.id)
 
     run_button.allow_tags = True
     run_button.short_description = 'Run'
@@ -279,11 +279,9 @@ class JobAdmin(admin.ModelAdmin):
     def stop_button(self, obj=None):
         if not obj or not obj.id:
             return ''
-        kwargs = dict(url='%d/stop/?inline=1' % obj.id, disabled='')
-        if not obj.is_running:
-            kwargs['disabled'] = 'disabled'
-        s = '<a href="{url}" class="button" {disabled}>Stop</a>'.format(**kwargs)
-        return format_html(s)
+        stop_url = '%d/stop/?inline=1' % obj.id
+        disabled = '' if obj.is_running else 'disabled'
+        return format_html('<a href="{}" class="button" {}>Stop</a>', stop_url, disabled)
 
     stop_button.allow_tags = True
     stop_button.short_description = 'Stop'
@@ -297,7 +295,9 @@ class JobAdmin(admin.ModelAdmin):
             id=obj.id,
             count=q.count(),
         )
-        return format_html('<a href="{url}?job__id__exact={id}"' ' target="_blank" class="button">View&nbsp;{count}</a>'.format(**kwargs))
+        return format_html(
+            '<a href="{}?job__id__exact={}" target="_blank" class="button">View&nbsp;{}</a>', kwargs['url'], kwargs['id'], kwargs['count']
+        )
 
     view_logs_button.allow_tags = True
     view_logs_button.short_description = 'Logs'
@@ -530,13 +530,13 @@ class LogAdmin(admin.ModelAdmin):
         return qs
 
     def stdout_link(self, obj):
-        return format_html('<a href="%s">Download</a>' % (reverse("admin:chroniker_log_stdout", args=(obj.id,)),))
+        return format_html('<a href="{}">Download</a>', reverse("admin:chroniker_log_stdout", args=(obj.id,)))
 
     stdout_link.allow_tags = True
     stdout_link.short_description = 'Stdout full'
 
     def stderr_link(self, obj):
-        return format_html('<a href="%s">Download</a>' % (reverse("admin:chroniker_log_stderr", args=(obj.id,)),))
+        return format_html('<a href="{}">Download</a>', reverse("admin:chroniker_log_stderr", args=(obj.id,)))
 
     stderr_link.allow_tags = True
     stderr_link.short_description = 'Stderr full'
@@ -607,7 +607,7 @@ class MonitorAdmin(admin.ModelAdmin):
         fmt = get_format('DATETIME_FORMAT')
         next_run = obj.next_run or timezone.now()
         value = capfirst(dateformat.format(utils.localtime(next_run), fmt))
-        return format_html("%s<br /><span class='mini'>(%s)</span>" % (value, obj.get_timeuntil()))
+        return format_html("{}<br /><span class='mini'>({})</span>", value, obj.get_timeuntil())
 
     get_timeuntil.admin_order_field = 'next_run'
     get_timeuntil.allow_tags = True
@@ -633,17 +633,18 @@ class MonitorAdmin(admin.ModelAdmin):
 
     def name_str(self, obj):
         if obj.monitor_url:
-            return format_html('<a href="%s" target="_blank">%s</a>' % (obj.monitor_url_rendered, obj.name))
+            return format_html('<a href="{}" target="_blank">{}</a>', obj.monitor_url_rendered, obj.name)
         return obj.name
 
     name_str.short_description = 'Name'
     name_str.allow_tags = True
 
     def action_buttons(self, obj):
-        buttons = []
-        buttons.append('<a href="%s" class="button">Check now</a>' % '%d/run/?inline=1' % obj.id)
-        buttons.append('<a href="/chroniker/job/%i/"' 'target="_blank" class="button">Edit</a>' % (obj.id,))
-        return format_html(' '.join(buttons))
+        buttons = [
+            format_html('<a href="{}" class="button">Check now</a>', '%d/run/?inline=1' % obj.id),
+            format_html('<a href="/chroniker/job/{}/" target="_blank" class="button">Edit</a>', obj.id),
+        ]
+        return mark_safe(' '.join(buttons))
 
     action_buttons.allow_tags = True
     action_buttons.short_description = 'Actions'
@@ -651,14 +652,14 @@ class MonitorAdmin(admin.ModelAdmin):
     def status(self, obj):
         if obj.is_running:
             help_text = 'The monitor is currently being checked.'
-            temp = '<img src="' + settings.STATIC_URL + 'admin/img/icon-unknown.svg" alt="%(help_text)s" title="%(help_text)s" />'
+            icon = 'admin/img/icon-unknown.svg'
         elif obj.last_run_successful:
             help_text = 'All checks passed.'
-            temp = '<img src="' + settings.STATIC_URL + 'admin/img/icon-yes.svg" alt="%(help_text)s" title="%(help_text)s" />'
+            icon = 'admin/img/icon-yes.svg'
         else:
             help_text = 'Requires attention.'
-            temp = '<img src="' + settings.STATIC_URL + 'admin/img/icon-no.svg" alt="%(help_text)s" title="%(help_text)s" />'
-        return format_html(temp % dict(help_text=help_text))
+            icon = 'admin/img/icon-no.svg'
+        return format_html('<img src="{}" alt="{}" title="{}" />', settings.STATIC_URL + icon, help_text, help_text)
 
     status.allow_tags = True
 

--- a/chroniker/models.py
+++ b/chroniker/models.py
@@ -39,7 +39,6 @@ from django.utils.safestring import mark_safe
 from django.utils.timesince import timeuntil
 from django.utils.translation import ngettext as ungettext, gettext as ugettext, gettext_lazy as _
 from django.core.exceptions import ValidationError
-from django.utils.html import format_html
 from toposort import toposort_flatten
 
 import chroniker.constants as c
@@ -1364,7 +1363,11 @@ class Log(models.Model):
         result = self.stdout or ''
         if len(result) > 40:
             result = result[:40] + '...'
-        return format_html(result) or '(No output)'
+        # Returned as a plain string so the template escapes it. This is
+        # arbitrary job output, and format_html() on a pre-built string marked
+        # it safe without escaping anything. stderr_sample below has always
+        # done it this way. See issue #403.
+        return result or '(No output)'
 
     def stderr_sample(self):
         result = self.stderr or ''

--- a/chroniker/tests/tests.py
+++ b/chroniker/tests/tests.py
@@ -36,6 +36,7 @@ from django.test.client import Client
 from django.utils import timezone
 
 from chroniker import constants as c, settings as _settings, utils
+from chroniker.admin import JobAdmin, LogAdmin, MonitorAdmin
 from chroniker.models import Job, Log
 
 warnings.simplefilter('error', RuntimeWarning)
@@ -815,3 +816,56 @@ class JobTestCase(TestCase):
 
         self.assertEqual(list(root_logger.handlers), handlers_before)
         self.assertEqual(root_logger.level, level_before)
+
+    def test_format_html_escapes_job_name(self):
+        """
+        Confirm a job name is escaped when rendered into admin markup.
+
+        format_html() on an already-interpolated string marks the result safe
+        without escaping anything that went into it, so a name typed into the
+        admin was injected into the page verbatim. Passing the values as
+        arguments is what runs them through conditional_escape(). This is also
+        why Django 6 rejects the no-argument form outright. See issue #403.
+        """
+        job = Job.objects.create(
+            name='<script>alert("xss")</script>',
+            raw_command="true",
+            is_monitor=True,
+            monitor_url='http://example.com/',
+        )
+
+        rendered = MonitorAdmin.name_str(None, job)
+
+        self.assertNotIn('<script>', rendered)
+        self.assertIn('&lt;script&gt;', rendered)
+
+    def test_admin_columns_render(self):
+        """
+        Confirm the admin display methods still render.
+
+        On Django 6, format_html() without arguments raises TypeError, which
+        took out the job changelist and the log change form entirely. Calling
+        each accessor directly catches that without needing a live admin
+        request. See issue #403.
+        """
+        job = Job.objects.create(
+            name="Test Job For Admin Columns",
+            raw_command="true",
+            enabled=True,
+            next_run=timezone.now() - timedelta(days=1),
+        )
+        job.run(update_heartbeat=0, force_run=True)
+        job.refresh_from_db()
+        log = Log.objects.filter(job=job).order_by('-id').first()
+        self.assertIsNotNone(log)
+
+        # Job changelist columns.
+        self.assertTrue(JobAdmin.get_timeuntil(None, job))
+        self.assertTrue(JobAdmin.run_button(None, job))
+        self.assertTrue(JobAdmin.stop_button(None, job))
+        self.assertTrue(JobAdmin.view_logs_button(None, job))
+        self.assertTrue(JobAdmin.last_run_with_link(None, job))
+
+        # Log change form columns.
+        self.assertTrue(LogAdmin.stdout_link(None, log))
+        self.assertTrue(LogAdmin.stderr_link(None, log))

--- a/chroniker/utils.py
+++ b/chroniker/utils.py
@@ -23,7 +23,7 @@ from django.db import connection
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import smart_str
-from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 
 from . import constants as c
 
@@ -527,8 +527,11 @@ def clean_samples(result):
     max_l = 10000
     if len(result) > max_l * 3:
         result = result[:max_l] + '\n...\n' + result[-max_l:]
+    # Already escaped above, and the <br/> substitutions below are markup we
+    # are adding on purpose, so this is mark_safe rather than format_html.
+    # format_html() with no args is an error as of Django 6. See issue #403.
     result = html.escape(result)
     result = result.replace('{', '  &#123;')
     result = result.replace('}', '&#125;')
     result = result.replace('\n', '<br/>')
-    return format_html(result)
+    return mark_safe(result)


### PR DESCRIPTION
Fixes #403

Thanks @tclancy — the report was accurate on every point, including the escaping consequence.

## Two problems, one cause

`format_html()` must be called with arguments as of Django 6.0 (deprecated in 5.0, deprecation ended). It was called with a pre-interpolated string in **13 places**, so on Django 6 the job changelist and the log change form raise `TypeError` instead of rendering — which is essentially the entire admin UI for this package.

**The escaping is the more important half.** `format_html(s)` marks an already-built string safe *without escaping anything that went into it* — which is exactly why Django removed the form. Two call sites were interpolating untrusted values into markup:

- **`MonitorAdmin.name_str`** put a job's `name` — free text typed into the admin — straight into an anchor.
- **`Log.stdout_sample`** passed arbitrary job stdout through `format_html`. `stderr_sample`, directly beside it, has always returned a plain string and let the template escape it; `stdout_sample` now matches.

Demonstrated against the unfixed code by the new test:

```
AssertionError: '<script>' unexpectedly found in
  '<a href="http://example.com/" target="_blank"><script>alert("xss")</script></a>'
```

## Call sites that aren't plain conversions

Two take fragments that are already safe, so argument-passing would be wrong:

- **`MonitorAdmin.action_buttons`** — builds each button with `format_html`, joins under `mark_safe`.
- **`utils.clean_samples`** — escapes its input itself and *then* inserts `<br/>` deliberately, so it uses `mark_safe`. Passing it as an argument would escape the markup it just built.

## Incidental fixes in code this touched

- `MonitorAdmin.status` left `icon` unset on its `is_running` branch (caught by pylint as `possibly-used-before-assignment` after the refactor — a live `UnboundLocalError` for any running monitor).
- `stop_button` shadowed the module-level `url` import.

## Tests

Both confirmed to **fail without the fix**:

- `test_format_html_escapes_job_name` — the XSS case above.
- `test_admin_columns_render` — exercises the accessors that raise on Django 6, without needing a live admin request.

## Verification

On 3.10 / Django 4.2: pylint **10.00/10** (exit 0) and **21/21** tests passing.

**Caveat worth stating plainly:** `tox.ini` pins `django42`, so CI *cannot* catch the Django 6 regression itself — as you noted, that pin is why this has been quiet. The escaping tests are version-independent and do run. Adding a Django 6 target to the matrix would be a sensible follow-up, and would also surface whatever else has drifted; I'd rather propose that separately than expand this PR.
