### PR TITLE
Convert datetimes to the current timezone for admin display

### DIFF
--- a/chroniker/tests/tests.py
+++ b/chroniker/tests/tests.py
@@ -1070,3 +1070,25 @@ class JobTestCase(TestCase):
         # positional request actually has to line up.
         name_field = Job._meta.get_field('name')
         self.assertIsNotNone(model_admin.formfield_for_dbfield(name_field, None))
+
+    def test_localtime_converts_to_current_timezone(self):
+        """
+        Confirm localtime() converts, rather than returning UTC unchanged.
+
+        It only called make_aware(), which returns an already-aware datetime
+        as-is. Values are stored in UTC and so are already aware, meaning the
+        admin displayed UTC no matter what TIME_ZONE was set to. See #88.
+        """
+        # settings.TIME_ZONE is America/New_York in the test settings, so a UTC
+        # value must come back with a non-zero offset.
+        stored = timezone.now()
+        converted = utils.localtime(stored)
+
+        self.assertEqual(converted, timezone.localtime(stored))
+        self.assertEqual(converted.utcoffset(), timezone.localtime(stored).utcoffset())
+        # Same instant, different wall clock.
+        self.assertEqual(converted.timestamp(), stored.timestamp())
+        self.assertNotEqual(converted.utcoffset(), stored.utcoffset())
+
+        # Must not blow up on None; the admin passes optional datetimes.
+        self.assertIsNone(utils.localtime(None))

--- a/chroniker/utils.py
+++ b/chroniker/utils.py
@@ -501,7 +501,21 @@ def make_aware(dt, tz):
 
 
 def localtime(dt):
+    """
+    Converts a datetime to the current timezone for display.
+
+    This used to only call make_aware(), which returns an aware datetime
+    unchanged. Values are stored in UTC, so they are already aware and came
+    back out still in UTC, meaning the admin showed UTC no matter what
+    TIME_ZONE was set to. See issue #88.
+
+    Only used for display; scheduling is unaffected.
+    """
+    if dt is None:
+        return dt
     dt = make_aware(dt, settings.TIME_ZONE)
+    if settings.USE_TZ and timezone.is_aware(dt):
+        return timezone.localtime(dt)
     return dt
 
 


### PR DESCRIPTION
Fixes #88

## The problem

`utils.localtime()` only called `make_aware()`, which returns an **already-aware** datetime unchanged. Datetimes are stored in UTC and so are already aware, meaning they came back out still in UTC — and the admin displayed UTC no matter what `TIME_ZONE` was set to.

Demonstrated against the test settings (`America/New_York`):

```
TIME_ZONE          : America/New_York
stored (UTC)       : 2026-08-18 20:50:51+00:00
utils.localtime()  : 2026-08-18 20:50:51+00:00   <-- what the admin displayed
django localtime() : 2026-08-18 16:50:51-04:00   <-- what it should be
```

A four-hour display error, which is exactly what @diegofcoelho described in 2017 and @billyquith seconded.

## The fix

Convert with `timezone.localtime()` once the value is aware, and return `None` unchanged since the admin passes optional datetimes.

**Display only.** All three callers are admin columns (`last_run_with_link` and the two `get_timeuntil` methods). Scheduling and storage are untouched and both remain in UTC — which is correct, and means this cannot shift when a job actually fires.

## Tests

`test_localtime_converts_to_current_timezone` asserts the instant is preserved (`.timestamp()` unchanged) while the offset changes, so it verifies a real conversion rather than a mangled value. Against unfixed code:

```
AssertionError: datetime.timedelta(0) != datetime.timedelta(days=-1, seconds=72000)
```

i.e. a UTC offset of zero where -4h was expected.

## Verification

Locally on 3.10: pylint **10.00/10** (exit 0) and **20/20** tests passing.
