### PR TITLE
Land the #399 and #400 fixes on master

### DIFF
--- a/chroniker/admin.py
+++ b/chroniker/admin.py
@@ -98,7 +98,7 @@ class JobAdmin(admin.ModelAdmin):
         'current_hostname',
         'current_pid',
         'job_type',
-        'is_due',
+        'is_due_display',
     )
     list_display_links = ('name',)
     list_filter = (
@@ -128,7 +128,7 @@ class JobAdmin(admin.ModelAdmin):
                 'classes': ('wide',),
                 'fields': (
                     'is_running',
-                    'is_due',
+                    'is_due_display',
                     'is_fresh',
                     'last_run_successful',
                     'total_parts',

--- a/chroniker/management/commands/cron.py
+++ b/chroniker/management/commands/cron.py
@@ -9,12 +9,26 @@ from multiprocessing import Queue
 
 import psutil
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.db import connection
 from django.utils import timezone
 
-from chroniker import settings as _settings, utils
-from chroniker.models import Job, Log
+# Children created by the "spawn" and "forkserver" start methods are fresh
+# interpreters that don't inherit the parent's django.setup(). They import
+# this module to unpickle the Process object, which pulls in chroniker.models
+# and fails with AppRegistryNotReady unless the registry is already populated.
+# This has to happen at import time; anything later is too late. It is a no-op
+# in the parent and under "fork", where setup() has already run.
+# See issues #99, #208 and #397.
+import django
+from django.apps import apps as _django_apps
+
+if not _django_apps.ready: # pragma: no cover
+    django.setup()
+
+# These must follow the setup() call above, not precede it.
+from chroniker import settings as _settings, utils # pylint: disable=wrong-import-position
+from chroniker.models import Job, Log # pylint: disable=wrong-import-position
 
 
 def kill_stalled_processes(dryrun=True):
@@ -213,6 +227,7 @@ def run_cron(jobs=None, **kwargs):
 
         if not dryrun:
             print("%d Jobs are due." % len(procs))
+            failed_procs = []
 
             # Wait for all job processes to complete.
             while procs:
@@ -230,6 +245,35 @@ def run_cron(jobs=None, **kwargs):
                     if not proc.is_alive():
                         print('Process %s ended.' % (proc,))
                         procs.remove(proc)
+
+                        # A child that dies before it can record its own log
+                        # row, e.g. on an import error, is otherwise
+                        # indistinguishable here from one that completed, and
+                        # cron would report success. See issue #397.
+                        if proc.exitcode:
+                            failed_procs.append(proc)
+                            print('Process %s exited with code %s.' % (proc, proc.exitcode), file=sys.stderr)
+                            connection.close()
+                            Job.objects.update()
+                            j = Job.objects.get(id=proc.job.id)
+                            if not Log.objects.filter(job=j, run_start_datetime=j.last_run_start_timestamp).exists():
+                                # The child never got far enough to log, so
+                                # record the failure on its behalf.
+                                Log.objects.create(
+                                    job=proc.job,
+                                    run_start_datetime=j.last_run_start_timestamp or timezone.now(),
+                                    run_end_datetime=timezone.now(),
+                                    success=False,
+                                    on_time=False,
+                                    hostname=socket.gethostname(),
+                                    stdout=''.join(stdout_map[proc.pid]),
+                                    stderr=''.join(stderr_map[proc.pid] + ['Job process exited with code %s\n' % proc.exitcode]),
+                                )
+                            proc.job.is_running = False
+                            proc.job.force_run = False
+                            proc.job.force_stop = False
+                            proc.job.last_run_successful = False
+                            proc.job.save()
                     elif proc.is_expired:
                         print('Process %s expired.' % (proc,))
                         proc_id = proc.pid
@@ -261,7 +305,15 @@ def run_cron(jobs=None, **kwargs):
 
                 time.sleep(1)
             print('!' * 80)
-            print('All jobs complete!')
+            if failed_procs:
+                print(
+                    '%d of the job processes failed: %s' % (len(failed_procs), ', '.join(str(_p) for _p in failed_procs)),
+                    file=sys.stderr,
+                )
+            else:
+                print('All jobs complete!')
+            return len(failed_procs)
+        return 0
     finally:
         if _settings.CHRONIKER_USE_PID and os.path.isfile(pid_fn) and clear_pid:
             os.unlink(pid_fn)
@@ -293,10 +345,16 @@ class Command(BaseCommand):
         # Find specific job ids to run, if any.
         jobs = [int(_.strip()) for _ in options.get('jobs', '').strip().split(',') if _.strip().isdigit()]
 
-        run_cron(
+        failures = run_cron(
             jobs,
             update_heartbeat=int(options['update_heartbeat']),
             force_run=options['force_run'],
             dryrun=options['dryrun'],
             sync=options['sync'],
         )
+
+        # Exit non-zero so a supervisor or systemd timer sees the failure.
+        # Without this, a job process that dies without running is reported
+        # as a clean run. See issue #397.
+        if failures:
+            raise CommandError('%d job process(es) failed.' % failures)

--- a/chroniker/models.py
+++ b/chroniker/models.py
@@ -247,12 +247,17 @@ class JobManager(models.Manager):
         kwargs = dict((_name, _value) for _name, _value in zip(_settings.CHRONIKER_JOB_NK, args))
         return self.get(**kwargs)
 
-    def due(self, job=None, check_running=True):
+    def due(self, job=None, check_running=True, check_hostname=True):
         """
         Returns a ``QuerySet`` of all jobs waiting to be run.  NOTE: this may
         return ``Job``s that are still currently running; it is your
         responsibility to call ``Job.check_is_running()`` to determine whether
         or not the ``Job`` actually needs to be run.
+
+        Set ``check_hostname=False`` to ignore the target hostname. That is
+        only appropriate for display, such as the admin's "is due" column,
+        where the question is whether the job is due at all rather than
+        whether this particular host should run it. See issue #128.
         """
 
         # Lock the Job record if possible with the backend.
@@ -265,20 +270,20 @@ class JobManager(models.Manager):
         else:
             q = self.all()
         q = q.filter(Q(next_run__lte=timezone.now()) | Q(force_run=True))
-        q = q.filter(
-            Q(hostname__isnull=True) | \
-            Q(hostname='') | \
-            Q(hostname=socket.gethostname()) | \
-            Q(hostname='*')
-            )
+        if check_hostname:
+            q = q.filter(
+                Q(hostname__isnull=True) | \
+                Q(hostname='') | \
+                Q(hostname=socket.gethostname()) | \
+                Q(hostname='*')
+                )
         q = q.filter(enabled=True)
         if check_running:
             # Get jobs that aren't running and potentially-running every-host jobs
             q = q.filter(Q(is_running=False) | Q(hostname="*"))
         if job is not None:
-            if isinstance(job, int):
-                job = job.id
-            q = q.filter(id=job.id)
+            # Accept either a Job or a raw id.
+            q = q.filter(id=job if isinstance(job, int) else job.id)
         return q
 
     def due_with_met_dependencies(self, jobs=None):
@@ -911,6 +916,20 @@ class Job(models.Model):
         return res
 
     is_due.boolean = True
+
+    def is_due_display(self):
+        """
+        Whether the job is due, ignoring the target hostname.
+
+        The admin may well be served from a different host than the one
+        running the jobs, in which case the hostname filter in due() makes
+        this column read False for every job targeting the cron host. For
+        display the hostname is not the interesting part. See issue #128.
+        """
+        return self.is_due(check_hostname=False)
+
+    is_due_display.boolean = True
+    is_due_display.short_description = _('is due')
 
     def is_due_with_dependencies_met(self, running_ids=None):
         """

--- a/chroniker/tests/tests.py
+++ b/chroniker/tests/tests.py
@@ -762,3 +762,58 @@ class JobTestCase(TestCase):
 
         # Empty args must not raise.
         self.assertEqual(Job(args='').get_args(), ([], {}))
+    def test_is_due_display_ignores_hostname(self):
+        """
+        Confirm the admin's "is due" column ignores the target hostname.
+
+        due() filters on socket.gethostname() so the scheduler only picks up
+        jobs meant for this host. When the admin is served from a different
+        host than the cron runner, that made the column read False for every
+        job targeting the cron host. See issue #128.
+        """
+        job = Job.objects.create(
+            name="Test Job For Another Host",
+            raw_command="true",
+            enabled=True,
+            hostname='some-other-host.example.com',
+            next_run=timezone.now() - timedelta(days=1),
+        )
+
+        # The scheduler must still skip it; this host is not the target.
+        self.assertFalse(job.is_due())
+        self.assertNotIn(job.id, [j.id for j in Job.objects.due()])
+
+        # ...but the admin column reports it as due, which it is.
+        self.assertTrue(job.is_due_display())
+
+        # A job targeting no particular host is due either way.
+        local_job = Job.objects.create(
+            name="Test Job For Any Host",
+            raw_command="true",
+            enabled=True,
+            hostname='',
+            next_run=timezone.now() - timedelta(days=1),
+        )
+        self.assertTrue(local_job.is_due())
+        self.assertTrue(local_job.is_due_display())
+
+        # A disabled job is due under neither.
+        job.enabled = False
+        job.save()
+        self.assertFalse(job.is_due_display())
+
+    def test_due_accepts_job_id(self):
+        """
+        Confirm due() accepts a raw id as well as a Job instance.
+
+        The isinstance check was inverted, so passing an int raised
+        AttributeError: 'int' object has no attribute 'id'.
+        """
+        job = Job.objects.create(
+            name="Test Job By Id",
+            raw_command="true",
+            enabled=True,
+            next_run=timezone.now() - timedelta(days=1),
+        )
+        self.assertIn(job.id, [j.id for j in Job.objects.due(job=job.id)])
+        self.assertIn(job.id, [j.id for j in Job.objects.due(job=job)])

--- a/chroniker/tests/tests.py
+++ b/chroniker/tests/tests.py
@@ -6,7 +6,9 @@ Quick run with:
 """
 from __future__ import print_function
 
+import multiprocessing
 import os
+import pickle
 import socket
 import sys
 import tempfile
@@ -35,6 +37,7 @@ from django.test.client import Client
 from django.utils import timezone
 
 from chroniker import constants as c, settings as _settings, utils
+from chroniker.management.commands import cron as chroniker_cron
 from chroniker.models import Job, Log
 
 warnings.simplefilter('error', RuntimeWarning)
@@ -817,3 +820,91 @@ class JobTestCase(TestCase):
         )
         self.assertIn(job.id, [j.id for j in Job.objects.due(job=job.id)])
         self.assertIn(job.id, [j.id for j in Job.objects.due(job=job)])
+
+    def test_timed_process_is_picklable(self):
+        """
+        Confirm a TimedProcess can be serialized for the spawn/forkserver
+        start methods.
+
+        These pickle the Process object to reach the child, so an open stream
+        stored on the instance makes every job unstartable. Python 3.14 made
+        forkserver the default on Linux, so this stopped being an edge case.
+        See issues #99, #208 and #397.
+        """
+        proc = utils.TimedProcess(max_seconds=10)
+
+        # The stream must not be held on the instance...
+        self.assertIsNone(proc.__dict__.get('_fout'))
+        # ...but must still resolve for the parent, which does the printing.
+        self.assertTrue(hasattr(proc.fout, 'write'))
+
+        # __getstate__ is what spawn/forkserver hand to the child. No open
+        # stream may survive it, whether or not one was supplied explicitly.
+        # (The Process object as a whole is never pickled directly here;
+        # multiprocessing blocks that for any Process, so the state dict is
+        # what we can meaningfully assert on.)
+        for supplied in (None, sys.stderr):
+            p = utils.TimedProcess(max_seconds=10, fout=supplied)
+            state = p.__getstate__()
+            self.assertIsNone(state['_fout'])
+            self.assertIsNone(state['_p'])
+            # Every remaining value must survive a round trip; an open stream
+            # here is exactly what used to break spawn.
+            for key, value in state.items():
+                if key == '_config':
+                    # multiprocessing's own bookkeeping, never our concern.
+                    continue
+                try:
+                    pickle.dumps(value)
+                except Exception as exc: # pylint: disable=broad-except
+                    self.fail('TimedProcess state %r is not picklable: %s' % (key, exc))
+
+    def test_cron_reports_failed_job_process(self):
+        """
+        Confirm cron notices a job process that dies without running.
+
+        The wait loop used to check only is_alive(), so a child that died on
+        import was indistinguishable from one that finished: cron printed
+        'All jobs complete!' and exited 0, leaving jobs silently un-run under
+        a supervisor or systemd timer. See issue #397.
+        """
+
+        # This test monkeypatches the process target, which means the target
+        # has to reach the child through inheritance rather than pickling: a
+        # local function can't be pickled, and a module-level one wouldn't help
+        # either, since a spawned child re-imports the unpatched module and
+        # never sees the patch. Defect 3 is start-method-independent, so pin
+        # fork for the duration and lose nothing. Reported by @tclancy, who hit
+        # this on macOS where spawn is the default.
+        original_start_method = multiprocessing.get_start_method(allow_none=True)
+        multiprocessing.set_start_method('fork', force=True)
+        if original_start_method:
+            self.addCleanup(multiprocessing.set_start_method, original_start_method, force=True)
+
+        job = Job.objects.create(
+            name="Test Job That Dies",
+            raw_command="true",
+            enabled=True,
+            next_run=timezone.now() - timedelta(days=1),
+        )
+
+        # Force the job process to die before it can record a log row, which
+        # is what an import error in a spawned child looks like from here.
+        original_run_job = chroniker_cron.run_job
+
+        def die_immediately(*args, **kwargs):
+            os._exit(1) # pylint: disable=protected-access
+
+        chroniker_cron.run_job = die_immediately
+        try:
+            failures = chroniker_cron.run_cron([job.id], update_heartbeat=0, force_run=True)
+        finally:
+            chroniker_cron.run_job = original_run_job
+
+        self.assertEqual(failures, 1)
+
+        job.refresh_from_db()
+        self.assertEqual(job.last_run_successful, False)
+        self.assertFalse(job.is_running)
+        # A failure that produced no log of its own must still be recorded.
+        self.assertTrue(Log.objects.filter(job=job, success=False).exists())

--- a/chroniker/utils.py
+++ b/chroniker/utils.py
@@ -17,7 +17,6 @@ except ImportError:
 import psutil
 
 from django.conf import settings
-from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db import connection
 from django.urls import reverse
@@ -61,12 +60,17 @@ def get_remaining_seconds(*args, **kwargs):
 
 
 def get_admin_change_url(obj):
+    # Imported lazily. A module-scope model import makes this module
+    # unimportable until the app registry is ready, which breaks
+    # spawn/forkserver children as they unpickle. See issue #397.
+    from django.contrib.contenttypes.models import ContentType # pylint: disable=import-outside-toplevel
     ct = ContentType.objects.get_for_model(obj)
     change_url_name = 'admin:%s_%s_change' % (ct.app_label, ct.model)
     return reverse(change_url_name, args=(obj.id,))
 
 
 def get_admin_changelist_url(obj):
+    from django.contrib.contenttypes.models import ContentType # pylint: disable=import-outside-toplevel
     ct = ContentType.objects.get_for_model(obj)
     list_url_name = 'admin:%s_%s_changelist' % (ct.app_label, ct.model)
     return reverse(list_url_name)
@@ -275,7 +279,12 @@ class TimedProcess(Process):
 
     def __init__(self, max_seconds, time_type=c.MAX_TIME, fout=None, check_freq=1, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fout = fout or sys.stdout
+        # Deliberately not falling back to sys.stdout here. The "spawn" and
+        # "forkserver" start methods pickle the Process object to reach the
+        # child, and an open stream can't be pickled, so storing one makes the
+        # process unstartable. Resolved lazily in the fout property instead.
+        # See issues #99, #208 and #397.
+        self._fout = fout
         self.t0 = time.process_time()
         self.t0_objective = time.time()
         self.max_seconds = float(max_seconds)
@@ -287,6 +296,29 @@ class TimedProcess(Process):
         self._p = None
         self._process_times = {} # {pid:user_seconds}
         self._last_duration_seconds = None
+
+    def __getstate__(self):
+        # An explicitly-supplied stream still can't be pickled, and fout is
+        # only ever read in the parent, so drop it when handing state to a
+        # spawn/forkserver child rather than letting start() fail.
+        state = self.__dict__.copy()
+        state['_fout'] = None
+        state['_p'] = None
+        return state
+
+    @property
+    def fout(self):
+        """
+        The stream progress messages are written to.
+
+        Resolved on access rather than stored, so the instance stays
+        picklable for spawn/forkserver. Only ever read in the parent.
+        """
+        return self._fout or sys.stdout
+
+    @fout.setter
+    def fout(self, value):
+        self._fout = value
 
     def terminate(self, sig=15, *args, **kwargs):
         """


### PR DESCRIPTION
## The problem

**PRs #399 and #400 are marked merged, but their fixes are not on master.**

Both were merged into `deps/upgrade-test-tooling-py39`. #398 had already taken that branch to master *before* they arrived, so the branch was never merged again and their commits were stranded there:

```
$ git log --oneline origin/master..origin/deps/upgrade-test-tooling-py39 --no-merges
7bab255 Make cron work under the spawn and forkserver start methods     # PR #399
204f0f7 Stop the admin's "is due" column depending on the viewing host  # PR #400

$ git branch -r --contains 7bab255
  origin/deps/upgrade-test-tooling-py39     # <- not origin/master
```

That's my fault — I targeted those PRs at the `deps/` branch to keep their diffs focused, which stopped being right the moment #398 landed on master.

So these remain live in shipped code despite showing as fixed:

- **#397, #208, #99** — `cron` unusable under `spawn`/`forkserver`, and job process failures reported as clean runs (exit 0 under systemd while nothing runs).
- **#128** — admin "is due" column reads False for every job with a target hostname when the admin and cron runner are different machines.

## This PR

Merges the branch into master to bring both across. The only conflict was the familiar one in `tests.py`, where each branch appended test methods at the same point; resolved as the union, keeping all seven tests and the imports each side needed.

No source changes beyond what #399 and #400 already carried — `models.py` auto-merged cleanly against #13's changes.

## Verification

Confirmed the fixes are actually present after the merge, rather than trusting the merge:

- `_fout` / `__getstate__` in `utils.py`, `failed_procs` in `cron.py` (#399)
- `is_due_display` / `check_hostname` in `models.py` (#400)
- `log_handler` from #404 still intact

On 3.10: pylint **10.00/10** (exit 0) and **25/25** tests passing — every test from all merged work together.

## Suggestion

Worth deleting `deps/upgrade-test-tooling-py39` after this merges, so nothing else gets targeted at it by mistake. My remaining PRs (#405, #406) target `master` directly.
