### PR TITLE
Match Django's formfield_for_dbfield signature

### DIFF
--- a/chroniker/admin.py
+++ b/chroniker/admin.py
@@ -443,8 +443,7 @@ class JobAdmin(admin.ModelAdmin):
 
     enable_jobs.short_description = "Enable selected jobs"
 
-    def formfield_for_dbfield(self, db_field, **kwargs):
-        request = kwargs.pop("request", None)
+    def formfield_for_dbfield(self, db_field, request, **kwargs):
 
         # Add a select field of available commands
         if db_field.name == 'command':
@@ -462,8 +461,7 @@ class JobAdmin(admin.ModelAdmin):
             kwargs['widget'] = forms.widgets.Select(choices=choices)
             return db_field.formfield(**kwargs)
 
-        kwargs['request'] = request
-        return super().formfield_for_dbfield(db_field, **kwargs)
+        return super().formfield_for_dbfield(db_field, request, **kwargs)
 
 
 class LogAdmin(admin.ModelAdmin):

--- a/chroniker/tests/tests.py
+++ b/chroniker/tests/tests.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 import logging
 import multiprocessing
 import pickle
+from django.contrib.admin import site as django_admin_site
 import os
 import socket
 import sys
@@ -1042,3 +1043,30 @@ class JobTestCase(TestCase):
         self.assertFalse(job.is_running)
         # A failure that produced no log of its own must still be recorded.
         self.assertTrue(Log.objects.filter(job=job, success=False).exists())
+
+    def test_formfield_for_dbfield_accepts_request(self):
+        """
+        Confirm the admin's formfield_for_dbfield matches Django's signature.
+
+        Django calls it as formfield_for_dbfield(db_field, request, **kwargs),
+        passing request positionally. JobAdmin declared it as
+        (self, db_field, **kwargs) and pulled request back out of kwargs, so
+        rendering the form raised:
+
+            TypeError: formfield_for_dbfield() missing 1 required positional
+            argument: 'request'
+
+        See issue #192.
+        """
+        model_admin = JobAdmin(Job, django_admin_site)
+
+        # The 'command' field takes the special-cased branch that builds a
+        # Select of available management commands.
+        command_field = Job._meta.get_field('command')
+        formfield = model_admin.formfield_for_dbfield(command_field, None)
+        self.assertIsNotNone(formfield)
+
+        # Any other field falls through to super(), which is where the
+        # positional request actually has to line up.
+        name_field = Job._meta.get_field('name')
+        self.assertIsNotNone(model_admin.formfield_for_dbfield(name_field, None))


### PR DESCRIPTION
Fixes #192

@SubrahmanyaG diagnosed this correctly in 2020 — thanks, and sorry it sat this long.

## The problem

Django calls `formfield_for_dbfield(db_field, request, **kwargs)` with `request` **positional**. `JobAdmin` declared it as `(self, db_field, **kwargs)` and pulled `request` back out of `kwargs`:

```python
def formfield_for_dbfield(self, db_field, **kwargs):
    request = kwargs.pop("request", None)
```

So any call from Django raises:

```
TypeError: JobAdmin.formfield_for_dbfield() takes 2 positional arguments but 3 were given
```

Reproduced directly against the current code, which is the same failure reported in the issue when rendering the admin form.

## The fix

Use Django's signature, and drop the `kwargs['request'] = request` round-trip that existed only to work around it.

Worth noting the two implementations in `chroniker/widgets.py` (`ImproveRawIdFieldsForm` and `ImproveRawIdFieldsFormTabularInline`) **already** use the correct signature — this brings `JobAdmin` in line with them rather than introducing a new convention.

## Tests

`test_formfield_for_dbfield_accepts_request` covers both branches: the special-cased `command` field that builds a Select of management commands, and a plain field that falls through to `super()` — the latter matters because that's where the positional argument has to line up. Against unfixed code:

```
TypeError: JobAdmin.formfield_for_dbfield() takes 2 positional arguments but 3 were given
```

## Verification

On 3.10: pylint **10.00/10** (exit 0) and **22/22** tests passing.
