### PR TITLE
Document how Job.update_progress() is meant to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,16 @@ This package contains the following improvements over the parent Chronograph pro
 
         from chroniker.models import Job
         Job.update_progress(total_parts=77, total_parts_complete=13)
-    
+
+    Call this from inside the management command, while it is being run by
+    chroniker. It is a classmethod that finds the job through a thread-local
+    set up by the runner, so there is no need to look the job up or pass it
+    around. It has no effect if the command is run directly, e.g. by hand from
+    `manage.py`, since there is no job running to report progress for. It also
+    cannot be used to update some other job from outside; calling it on an
+    instance such as `job.update_progress(...)` updates whichever job is
+    running in the current thread, not `job`.
+
 * Improved logging of management command stdout and stderr, and efficiently displaying these in admin.
 * Creation of the `Monitor` model, a proxy of the `Job` model, to allow easier setup of system and database state monitoring.
 * Addition of a model for documenting inter-job dependencies as well as flags for controlling job behavior based on these dependencies. e.g. You can configure one job to not run until another job has successfully run, or run at a later date.

--- a/chroniker/models.py
+++ b/chroniker/models.py
@@ -1225,9 +1225,25 @@ class Job(models.Model):
 
     @classmethod
     def update_progress(cls, *args, **kwargs):
+        """
+        Records progress for the job running in the current thread.
+
+        Call this from inside a management command while chroniker is running
+        it. The job is found through a thread-local set up by the runner, so
+        this is a classmethod and takes no job argument; calling it on an
+        instance still updates the running job rather than that instance.
+
+        Does nothing when no job is running in this thread, e.g. when the
+        command is run by hand. See issue #104.
+        """
         heartbeat = get_current_heartbeat()
         if heartbeat:
             return heartbeat.update_progress(*args, **kwargs)
+        logger.debug(
+            'Job.update_progress() called with no job running in this thread; '
+            'ignoring. It only has an effect inside a command being run by chroniker.'
+        )
+        return None
 
 
 class Log(models.Model):

--- a/chroniker/tests/tests.py
+++ b/chroniker/tests/tests.py
@@ -869,3 +869,29 @@ class JobTestCase(TestCase):
         # Log change form columns.
         self.assertTrue(LogAdmin.stdout_link(None, log))
         self.assertTrue(LogAdmin.stderr_link(None, log))
+
+    def test_update_progress_outside_a_job_is_a_noop(self):
+        """
+        Confirm update_progress() is harmless when no job is running.
+
+        It is a classmethod that finds the job through a thread-local set up
+        by the runner, so it cannot be used to update an arbitrary job from
+        outside. Calling it on an instance updates whichever job is running in
+        the current thread, not that instance, which is why it looked like
+        "nothing really happens" in issue #104.
+        """
+        job = Job.objects.create(
+            name="Test Job For Progress",
+            raw_command="true",
+            total_parts=0,
+            total_parts_complete=0,
+        )
+
+        # No job is running in this thread, so this must not raise and must
+        # not touch the instance it was called on.
+        self.assertIsNone(Job.update_progress(total_parts=77, total_parts_complete=13))
+        self.assertIsNone(job.update_progress(total_parts=77, total_parts_complete=13))
+
+        job.refresh_from_db()
+        self.assertEqual(job.total_parts, 0)
+        self.assertEqual(job.total_parts_complete, 0)


### PR DESCRIPTION
Fixes #104

## What was happening

@diegofcoelho's question was reasonable and the answer was nowhere in the docs.

`Job.update_progress()` is a **classmethod** that locates the running job through a thread-local set up by the runner:

```python
@classmethod
def update_progress(cls, *args, **kwargs):
    heartbeat = get_current_heartbeat()
    if heartbeat:
        return heartbeat.update_progress(*args, **kwargs)
```

So it only does anything when called from **inside a management command that chroniker is running**, and it cannot be used to update some other job from outside. Calling it on an instance —

```python
job_obj = Job.objects.get(pk=9)
job_obj.update_progress(total_parts=n, total_parts_complete=m)
```

— updates whichever job is running in the current thread, **not** `job_obj`. Outside a job there is no heartbeat, so it returned `None` and did nothing, with no indication why. Exactly "nothing really happens".

## Changes

- **README** — explains that the call belongs inside the command, that it takes no job argument by design, and that it has no effect when the command is run by hand.
- **Docstring** — the same, at the method.
- **Debug log** on the no-op path, so the silent case is at least visible to anyone who turns logging up.

**No behaviour change.** I deliberately did *not* make the no-op raise: commands are often run both under chroniker and by hand, and raising would break the latter.

## Tests

`test_update_progress_outside_a_job_is_a_noop` covers both the classmethod and instance forms, and asserts the instance it was called on is left untouched.

## Verification

On 3.10: pylint **10.00/10** (exit 0) and **22/22** tests passing.
