### PR TITLE
Make process termination survive timeouts it cannot interrupt

### DIFF
--- a/chroniker/settings.py
+++ b/chroniker/settings.py
@@ -71,3 +71,9 @@ CHRONIKER_JOB_ERROR_CALLBACK = settings.CHRONIKER_JOB_ERROR_CALLBACK = getattr(s
 # applies to records captured while a job runs; it does not affect any handler
 # configured in settings.LOGGING. See issue #13.
 CHRONIKER_LOG_FORMAT = settings.CHRONIKER_LOG_FORMAT = getattr(settings, 'CHRONIKER_LOG_FORMAT', '%(levelname)s %(name)s %(message)s')
+
+# Seconds to wait after SIGTERM before sending SIGKILL to a job that has
+# exceeded its timeout. SIGTERM cannot interrupt a process blocked in a
+# syscall, e.g. one waiting on a database query, so without an escalation a
+# job can run far past its timeout. See issue #118.
+CHRONIKER_KILL_GRACE_SECONDS = settings.CHRONIKER_KILL_GRACE_SECONDS = getattr(settings, 'CHRONIKER_KILL_GRACE_SECONDS', 30)

--- a/chroniker/tests/tests.py
+++ b/chroniker/tests/tests.py
@@ -1092,3 +1092,35 @@ class JobTestCase(TestCase):
 
         # Must not blow up on None; the admin passes optional datetimes.
         self.assertIsNone(utils.localtime(None))
+
+    def test_terminate_unstarted_process_does_not_raise(self):
+        """
+        Confirm terminate() is safe on a process with no live handle.
+
+        The final kill dereferenced self._p.pid outside the guard that checks
+        it, so terminating a process that was never started, or that had
+        already been reaped, raised
+
+            AttributeError: 'NoneType' object has no attribute 'pid'
+
+        That is reachable from cron's expiry branch, where it took down the
+        whole run rather than just the job being cleaned up. See issue #118.
+        """
+        proc = utils.TimedProcess(max_seconds=1)
+        self.assertIsNone(proc._p) # pylint: disable=protected-access
+        proc.terminate()
+
+    def test_kill_grace_seconds_default(self):
+        """
+        Confirm the SIGTERM-to-SIGKILL grace period is configurable.
+
+        SIGTERM cannot interrupt a process blocked in a syscall, e.g. one
+        waiting on a database query, so a job could sit well past its timeout
+        being "terminated" on every pass. See issue #118.
+        """
+        proc = utils.TimedProcess(max_seconds=1)
+        self.assertEqual(proc.kill_grace_seconds, _settings.CHRONIKER_KILL_GRACE_SECONDS)
+
+        # Explicit values win over the setting.
+        proc = utils.TimedProcess(max_seconds=1, kill_grace_seconds=5)
+        self.assertEqual(proc.kill_grace_seconds, 5)

--- a/chroniker/utils.py
+++ b/chroniker/utils.py
@@ -277,7 +277,7 @@ class TimedProcess(Process):
 
     daemon = True
 
-    def __init__(self, max_seconds, time_type=c.MAX_TIME, fout=None, check_freq=1, *args, **kwargs):
+    def __init__(self, max_seconds, time_type=c.MAX_TIME, fout=None, check_freq=1, *args, kill_grace_seconds=None, **kwargs):
         super().__init__(*args, **kwargs)
         # Deliberately not falling back to sys.stdout here. The "spawn" and
         # "forkserver" start methods pickle the Process object to reach the
@@ -292,6 +292,10 @@ class TimedProcess(Process):
         self.t1_objective = None
         # The number of seconds the process waits between checks.
         self.check_freq = check_freq
+        # How long to wait after SIGTERM before escalating to SIGKILL.
+        if kill_grace_seconds is None:
+            kill_grace_seconds = getattr(settings, 'CHRONIKER_KILL_GRACE_SECONDS', 30)
+        self.kill_grace_seconds = kill_grace_seconds
         self.time_type = time_type
         self._p = None
         self._process_times = {} # {pid:user_seconds}
@@ -349,10 +353,16 @@ class TimedProcess(Process):
                 # Sum final time.
                 self._process_times[self._p.pid] = self._p.cpu_times().user
                 self._last_duration_seconds = sum(self._process_times.values())
-        os.system('kill -%i %i' % (
-            sig,
-            self._p.pid,
-        ))
+        # Guarded: a process that was never started, or that has already been
+        # reaped, has no _p, and this used to raise
+        # AttributeError: 'NoneType' object has no attribute 'pid'
+        # which took down the whole cron run rather than just this job.
+        # See issue #118.
+        if self._p:
+            os.system('kill -%i %i' % (
+                sig,
+                self._p.pid,
+            ))
         #return super(TimedProcess, self).terminate(*args, **kwargs)
 
     def get_duration_seconds_wall(self):
@@ -477,6 +487,23 @@ class TimedProcess(Process):
                     print('\nAttempting to terminate expired process %s...' % (self.pid,), file=self.fout)
                 timeout = True
                 self.terminate()
+
+                # SIGTERM does not interrupt a process blocked in a syscall,
+                # e.g. one waiting on a database query, so a job could sit
+                # well past its timeout while being "terminated" on every
+                # pass. Give it a grace period, then escalate to SIGKILL.
+                # See issue #118.
+                deadline = time.time() + self.kill_grace_seconds
+                while self.is_alive() and time.time() < deadline:
+                    time.sleep(0.5)
+                if self.is_alive():
+                    if verbose:
+                        print(
+                            '\nProcess %s ignored SIGTERM after %s seconds; sending SIGKILL.' %
+                            (self.pid, self.kill_grace_seconds),
+                            file=self.fout,
+                        )
+                    self.terminate(sig=9)
         self.t0 = time.process_time()
         self.t1_objective = time.time()
         return timeout


### PR DESCRIPTION
Fixes #118

@steffenmandrup reported two symptoms in 2018 — jobs running hours past a 200 second timeout, and the same job running multiple times at once. Both trace to `TimedProcess.terminate()`.

## 1. `terminate()` crashed on a process with no live handle

The final kill dereferenced `self._p.pid` **outside** the `if self.is_alive() and self._p` guard directly above it:

```python
if self.is_alive() and self._p:
    ...          # guarded work
os.system('kill -%i %i' % (sig, self._p.pid))   # <- not guarded
```

Reproduced:

```
_p is: None
terminate() FAILS -> AttributeError: 'NoneType' object has no attribute 'pid'
```

This is reachable from cron's expiry branch (`cron.py:280`), where it took down the **whole cron run** rather than just the job being cleaned up. Any jobs still being waited on were left marked running — which is one way to arrive at the duplicate runs in the report.

## 2. SIGTERM alone cannot stop a blocked process

`terminate()` sends SIGTERM, which a process blocked in a syscall — such as one waiting on a lock-contended database query — does not act on until that call returns. `start_then_kill()` would therefore "terminate" an expired job on every pass while it kept running, exactly matching "a timeout of 200 seconds can sometimes run for hours and hours before suddenly being released".

It now waits a grace period after SIGTERM and escalates to SIGKILL if the process is still alive. Configurable via `CHRONIKER_KILL_GRACE_SECONDS` (default 30), or per-process with the keyword-only `kill_grace_seconds` argument.

## Tests

Both confirmed to **fail without the fix**:

- `test_terminate_unstarted_process_does_not_raise` — fails with the `AttributeError` above.
- `test_kill_grace_seconds_default` — covers the setting and the per-process override.

## Verification

On 3.10: pylint **10.00/10** (exit 0) and **32/32** tests passing.

## What this does not fix

I want to be clear about scope: this makes the timeout actually enforceable and stops one crash path that can strand jobs as running. If @steffenmandrup's duplicates came from a *different* route — for example stale-job cleanup racing a live process — that would still be open. I could not reproduce the duplicate-run half directly, so I have fixed what I could demonstrate rather than claiming the whole report.
