### PR TITLE
Keep cronserver running through a failing tick

### DIFF
--- a/chroniker/management/commands/cronserver.py
+++ b/chroniker/management/commands/cronserver.py
@@ -6,6 +6,7 @@ from threading import Thread
 
 from django.core.management.base import BaseCommand
 from django.core.management import call_command
+from django.db import connection
 from django.utils.translation import gettext_lazy as _
 
 logger = logging.getLogger('chroniker.commands.cronserver')
@@ -16,7 +17,20 @@ class CronThread(Thread):
 
     def run(self):
         logger.info("Running due jobs...")
-        call_command('cron')
+        try:
+            call_command('cron')
+        except Exception: # pylint: disable=broad-except
+            # A transient failure, most often the database being briefly
+            # unreachable, used to escape as an unhandled traceback in the
+            # thread and leave a dead connection behind. The outer loop keeps
+            # starting new threads either way, so log it and close the
+            # connection so the next tick starts clean rather than inheriting
+            # a broken one. See issue #193.
+            logger.exception('Error running due jobs; will retry on the next tick.')
+            try:
+                connection.close()
+            except Exception: # pylint: disable=broad-except
+                logger.exception('Error closing the database connection.')
 
 
 class Command(BaseCommand):

--- a/chroniker/tests/tests.py
+++ b/chroniker/tests/tests.py
@@ -39,6 +39,7 @@ from django.test.client import Client
 from django.utils import timezone
 
 from chroniker import constants as c, settings as _settings, utils
+from chroniker.management.commands import cronserver
 from chroniker.management.commands import cron as chroniker_cron
 from chroniker.admin import JobAdmin, LogAdmin, MonitorAdmin
 from chroniker.models import Job, Log
@@ -1162,3 +1163,28 @@ class JobTestCase(TestCase):
         """
         job = Job.objects.create(name="Test Job Jitter None", raw_command="true", jitter_seconds=60)
         self.assertIsNone(job.apply_jitter(None))
+
+    def test_cronserver_thread_survives_a_failing_tick(self):
+        """
+        Confirm a failing tick does not escape the cronserver thread.
+
+        call_command('cron') was called unguarded, so a transient failure,
+        most often the database being briefly unreachable, escaped as an
+        unhandled traceback and left a dead connection behind. The outer loop
+        keeps starting threads either way, so the failure should be logged and
+        the connection closed rather than propagated. See issue #193.
+        """
+        original = cronserver.call_command
+
+        def explode(*args, **kwargs):
+            raise RuntimeError('simulated database outage')
+
+        cronserver.call_command = explode
+        try:
+            thread = cronserver.CronThread()
+            # Must not raise; run() is called directly rather than via start()
+            # so an escaping exception would surface here.
+            with self.assertLogs('chroniker.commands.cronserver', level='ERROR'):
+                thread.run()
+        finally:
+            cronserver.call_command = original


### PR DESCRIPTION
Fixes #193

## The reported failure was not ours; the handling of it was

The traceback in the issue originates outside chroniker:

```
psycopg2.OperationalError: could not translate host name
  "xxxxxxxxx.rds.amazonaws.com" to address: System error
```

That is DNS resolution failing, so the database was unreachable at that moment rather than misbehaving. Very likely an environment problem on the instance — which fits the "needs a restart every 2-3 days" pattern.

But the handling of it was ours. `CronThread.run()` called `call_command('cron')` **unguarded**:

```python
def run(self):
    logger.info("Running due jobs...")
    call_command('cron')
```

so any failure escaped as an unhandled traceback in the thread and left whatever database connection it was holding behind. The outer loop keeps starting new threads regardless, so each subsequent tick could inherit a broken connection. A transient outage should not need a process restart to recover from.

## The fix

Log the failure with its traceback and close the connection so the next tick starts clean.

The `except Exception` is deliberately broad. The whole point is that no failure mode should be able to kill the loop; narrowing it to database errors would leave every other exception behaving exactly as before. The connection close is itself guarded, since closing a connection that is already broken can raise.

## Tests

`test_cronserver_thread_survives_a_failing_tick` patches `call_command` to raise, calls `run()` directly so an escaping exception surfaces in the test, and asserts the error is logged instead. Against unfixed code it fails with the injected `RuntimeError` propagating.

## Verification

On 3.10: pylint **10.00/10** (exit 0) and **33/33** tests passing.

I could not reproduce the original DNS failure itself, so this fixes the resilience gap rather than the root cause. If the loop still stops entirely on a current version, that would be a different problem and worth reopening with fresh output.
